### PR TITLE
HTTP errors events

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2580,6 +2580,10 @@ Strophe.Connection.prototype = {
                      ", number of errors: " + this.errors);
         if (this.errors > 4) {
             this._onDisconnectTimeout();
+        } else {
+            if (window.jQuery !== undefined) {
+                window.jQuery(document).trigger('strophe-http-' + reqStatus + '-error');
+            }
         }
     },
 


### PR DESCRIPTION
report from https://github.com/metajack/strophejs/pull/93

As seen here http://stackoverflow.com/questions/8285053/why-there-is-no-error-thrown-with-strophe-js, Strophes handles HTTP connections and errors, but the client isn't notified when an HTTP error occurs. You might want to implement specific behaviour on a specific error (I do on 502 errors for instance), and this pull request fires a 'strophe-http-xxx-error' on a xxx HTTP error. I propose this request because I don't want to patch `_hitError` in my client code every time I use Strophe.

This a (safe) and very simple jQuery implementation, because I use jQuery myself. It should not fail if jQuery is not defined, but in this case it won't fire anything.

Ex :  do something on 502 HTTP errors :

```
$(document).bind('strophe-http-502-error', function (event) {
    // do something useful here
});
```
