### PR TITLE
add feedback on 4 undocumented (without reason) disconnect

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2395,7 +2395,7 @@ Strophe.Connection.prototype = {
                     this._changeConnectStatus(Strophe.Status.CONNFAIL,
                                               "bad-service");
                 }
-                this.disconnect();
+                this.disconnect("XHR open failed.");
                 return;
             }
 
@@ -2680,10 +2680,11 @@ Strophe.Connection.prototype = {
                     cond = "conflict";
                 }
                 this._changeConnectStatus(Strophe.Status.CONNFAIL, cond);
+                this.disconnect("received terminate : " + cond);
             } else {
                 this._changeConnectStatus(Strophe.Status.CONNFAIL, "unknown");
+                this.disconnect("received terminate : unknown condition");
             }
-            this.disconnect();
             return;
         }
 
@@ -2892,7 +2893,7 @@ Strophe.Connection.prototype = {
             // client connections
             this._changeConnectStatus(Strophe.Status.CONNFAIL,
                                       'x-strophe-bad-non-anon-jid');
-            this.disconnect();
+            this.disconnect('x-strophe-bad-non-anon-jid');
         } else if (this._authentication.sasl_scram_sha1) {
             var cnonce = MD5.hexdigest(Math.random() * 1234567890);
 
@@ -3439,7 +3440,7 @@ Strophe.Connection.prototype = {
             this._changeConnectStatus(Strophe.Status.CONNECTED, null);
         } else if (elem.getAttribute("type") == "error") {
             this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
-            this.disconnect();
+            this.disconnect('authentication failed');
         }
 
         return false;


### PR DESCRIPTION
report from https://github.com/metajack/strophejs/pull/92

Hi,
while developing my app, I encountered several cases of "Disconnect was called because: undefined" in my logs. That wasn't very helpful and I found 4 calls of this.disconnect() without reason :

```
/** Function: disconnect
 *  Start the graceful disconnection process. [...]
 *
 *  Parameters:
 *    (String) reason - The reason the disconnect is occuring.
 */
```

This patch adds feedback on these 4 undocumented disconnect. I hope it would be helpful to others.
