### PR TITLE
[error handling] Make noise when removing handlers due to uncaught exceptions.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2394,7 +2394,8 @@ Strophe.Connection.prototype = {
                         that.handlers.push(hand);
                     }
                 } catch(e) {
-                    //if the handler throws an exception, we consider it as false
+                    // if the handler throws an exception, we consider it as false
+                    Strophe.warn('Removing Strophe handlers due to uncaught exception: ' + e.message);
                 }
             }
         });


### PR DESCRIPTION
Handlers are removed if there are any uncaught exceptions in the handler flow, but there isn't any helpful debugging to point developers in the direction of what went wrong, or even that their handlers have been removed.

This pull request addresses that. Let me know if you'd prefer different language or anything.

This is what the the output looks like...

![screen shot 2013-06-20 at 3 44 25 pm](https://f.cloud.github.com/assets/427516/684461/02374180-d9fb-11e2-90e1-a3f394c75328.png)
