### PR TITLE
Removed dead code

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1843,8 +1843,7 @@ Strophe.Connection.prototype = {
 
         this._changeConnectStatus(Strophe.Status.CONNECTING, null);
 
-        var _connect_cb = this.connect_callback || this._connect_cb;
-        this.connect_callback = null;
+        var _connect_cb = this._connect_cb;
 
         this._requests.push(
             new Strophe.Request(body.tree(),


### PR DESCRIPTION
I remaved two variables from the code.
streamId is never used anywhere, just set to null repeatedly.
this._connect_callback looks like it's a typo from this.connect_callback, but if you change it to this, the callback that is passed to the connect method, that is supposed to be called after the connection is established will in fact overwrite the callback that establishes the connection, so I removed the variable. It is also never used anywhere else.
