### PR TITLE
[style] Use four space indentation instead of two on the changes in PR #11

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2425,12 +2425,12 @@ Strophe.Connection.prototype = {
             var sendFunc = function () {
                 req.date = new Date();
                 if (self._options.customHeaders){
-                  var headers = self._options.customHeaders;
-                  for (var header in headers) {
-                    if (headers.hasOwnProperty(header)) {
-                      req.xhr.setRequestHeader(header, headers[header]);
+                    var headers = self._options.customHeaders;
+                    for (var header in headers) {
+                        if (headers.hasOwnProperty(header)) {
+                            req.xhr.setRequestHeader(header, headers[header]);
+                        }
                     }
-                  }
                 }
                 req.xhr.send(req.data);
             };


### PR DESCRIPTION
Minor commit - Adjusts indentation from two to four spaces in part of the change set from my previous PR #11 to match the rest of the project.
