### PR TITLE
boshclient.py example doesn't always authenticate successfully

### DIFF
--- a/examples/attach/boshclient.py
+++ b/examples/attach/boshclient.py
@@ -110,7 +110,13 @@ class BOSHClient:
                     if elems[0].name == 'success':
                         retb, elems = self.sendBody(self.buildBody())
                         
-                        if elems[0].firstChildElement().name == 'bind':
+                        has_bind = False
+                        for child in elems[0].children:
+                            if child.name == 'bind':
+                                has_bind = True
+                                break
+
+                        if has_bind:
                             iq = domish.Element(('jabber:client', 'iq'))
                             iq['type'] = 'set'
                             iq.addUniqueId()


### PR DESCRIPTION
The boshclient.py example is buggy because when examining the response from the XMPP server, it only looks at the first child of `<success>` for the `<bind>` element.  However, `<bind>` might not be the first child; for example, in the XML returned from Prosody 0.8, it's the second child.

This commit fixes the code to look at all the children of `<success>` for a `<bind>` element.
