### PR TITLE
[attach] Apply the rid/jid/sid to the connection's _proto

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1855,6 +1855,11 @@ Strophe.Connection.prototype = {
         this.jid = jid;
         this.sid = sid;
         this.rid = rid;
+
+        this._proto.jid = jid;
+        this._proto.sid = sid;
+        this._proto.rid = rid;
+
         this.connect_callback = callback;
 
         this.domain = Strophe.getDomainFromJid(this.jid);


### PR DESCRIPTION
This solves an issue introduced in PR #10, which added Websocket support.

During session attachment, because the `attach` method is still part of `Strophe.Connection`, it is setting the `jid`, `sid`, and `rid` props of the `Strophe.Connection` instance, and not those of the `Strophe.Bosh` instance (which occupies the `._proto` property of the connection instance).

The issue makes itself obvious when you try to attach using bosh, and don't see the `sid` attribute on outgoing stanzas. This is because the code in `Strophe.Bosh.prototype._buildBody` checks for `this.sid`, but it isn't set on the `Strophe.Bosh` instance after attachment.

I don't know if this will cause any issues for the websocket side of things, or if it even matters (Do web socket connections even make use of `Connection.attach`?

Without this change, we can't connect using a normal prebind/attach routine. I'd love feedback.
