### PR TITLE
Change state after unexpectedly killed WebSockets

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2291,9 +2291,10 @@ Strophe.Connection.prototype = {
         }
 
         Strophe.info("_doDisconnect was called");
+        this._proto._doDisconnect();
+
         this.authenticated = false;
         this.disconnecting = false;
-        this._proto._doDisconnect();
 
         // tell the parent we disconnected
         if (this.connected) {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -206,7 +206,12 @@ Strophe.Websocket.prototype = {
      * Nothing to do here for WebSockets
      */
     _onClose: function(event) {
-        Strophe.info("Websocket closed");
+        if(this._conn.connected && !this._conn.disconnecting) {
+            Strophe.error("Websocket closed unexcectedly");
+            this._conn._doDisconnect();
+        } else {
+            Strophe.info("Websocket closed");
+        }
     },
 
     /** PrivateFunction: _no_auth_received


### PR DESCRIPTION
When WebSocket connections were killed (e.g. if a server crashed) Callbacks were not called and Status was not changed to DISCONNECTED. This is fixed here.
