### PR TITLE
Fixed legacy non-sasl auth

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2480,19 +2480,20 @@ Strophe.Connection.prototype = {
         var matched = [];
         var i, mech, auth_str, hashed_auth_str,
             found_authentication = false;
-        if (hasFeatures && mechanisms.length > 0) {
+        if (!hasFeatures) {
+            this._proto._no_auth_received(_callback);
+            return;
+        };
+        if (mechanisms.length > 0) {
             for (i = 0; i < mechanisms.length; i++) {
                 mech = Strophe.getText(mechanisms[i]);
                 if (this.mechanisms[mech]) matched.push(this.mechanisms[mech]);
             }
-
-            this._authentication.legacy_auth =
-                bodyWrap.getElementsByTagName("auth").length > 0;
-
-            found_authentication =
-                this._authentication.legacy_auth ||
-                matched.length > 0;
         }
+        this._authentication.legacy_auth =
+            bodyWrap.getElementsByTagName("auth").length > 0;
+        found_authentication = this._authentication.legacy_auth ||
+            matched.length > 0;
         if (!found_authentication) {
             this._proto._no_auth_received(_callback);
             return;


### PR DESCRIPTION
I've found a problem in how strophe works with stream:features when searching for non-sasl auth.
Here is an example from http://xmpp.org/extensions/xep-0078.html

```
<stream:features>
    <mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
      <mechanism>DIGEST-MD5</mechanism>
      <mechanism>PLAIN</mechanism>
    </mechanisms>
    <auth xmlns='http://jabber.org/features/iq-auth'/>
  </stream:features>
```

As I understand xep-0078 and this example, auth tag should be checked separately and it hasn't to be dependent on mechanisms.
