### PR TITLE
Add sync option to BOSH

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -644,7 +644,7 @@ Strophe.Bosh.prototype = {
                           "." + req.sends + " posting");
 
             try {
-                req.xhr.open("POST", this._conn.service, true);
+                req.xhr.open("POST", this._conn.service, this._conn._options.sync ? false : true);
             } catch (e2) {
                 Strophe.error("XHR open failed.");
                 if (!this._conn.connected) {


### PR DESCRIPTION
Fix for metajack/strophejs#16 and strophe/strophejs#47.

I used part of the patch @Gordin proposed in strophe/strophejs#47 in order to bring this feature finally to strophe :).

Use e.g. like:

``` javascript
// _connection == Strophe.Connection instance
_connection._options.sync = true;
disconnect();
_connection.flush()
```
