### PR TITLE
Fixed test failures due to IE11 attribute order in XML DOM builder.

### DIFF
--- a/tests/comparison.js
+++ b/tests/comparison.js
@@ -1,0 +1,19 @@
+/** Function: assertRegexMatch
+ *  An assertion using regex.
+ *
+ *  Parameters:
+ *    (String) text - String to search.
+ *    (RegExp) pattern - Regular expression.
+ *    (String) message - Error message.
+ */
+function assertRegexMatch(text, pattern, message)
+{
+	var newMessage = message;
+	var isMatch = pattern.test(text);
+	if( !isMatch ){
+		newMessage = 'Text "' + text + '" does not match pattern "' + pattern + '".';
+		if( typeof message === 'string'  &&  message.length > 0 )
+			newMessage += (' ' + message);
+	}
+	ok( isMatch, newMessage );
+}

--- a/tests/strophe.html
+++ b/tests/strophe.html
@@ -17,6 +17,7 @@
     <script src="http://cjohansen.no/sinon/releases/sinon-qunit-0.8.0.js"></script>
     <script src='../strophe.js'></script>
     <script src='tests.js'></script>
+    <script src='comparison.js'></script>
     
     <title>Strophe.js Tests</title>
   </head>


### PR DESCRIPTION
In the Builder portion of the test suite, IE11 was generating XML attributes in a different order from other browsers. I created a regex-based assertion to test the emitted XML, tested with IE11, FireFox, and Chrome.
