### PR TITLE
getElementByTagName problem with namespaced elements

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2420,10 +2420,7 @@ Strophe.Connection.prototype = {
         this._authentication.legacy_auth = false;
 
         // Check for the stream:features tag
-        var hasFeatures = bodyWrap.getElementsByTagName("stream:features").length > 0;
-        if (!hasFeatures) {
-            hasFeatures = bodyWrap.getElementsByTagName("features").length > 0;
-        }
+        var hasFeatures = bodyWrap.getElementsByTagNameNS(Strophe.NS.STREAM, "features").length > 0;
         var mechanisms = bodyWrap.getElementsByTagName("mechanism");
         var matched = [];
         var i, mech, found_authentication = false;

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -93,7 +93,7 @@ Strophe.Websocket.prototype = {
      *     true if there was a streamerror, false otherwise.
      */
     _check_streamerror: function (bodyWrap, connectstatus) {
-        var errors = bodyWrap.getElementsByTagName("stream:error");
+        var errors = bodyWrap.getElementsByTagNameNS(Strophe.NS.STREAM, "error");
         if (errors.length === 0) {
             return false;
         }


### PR DESCRIPTION
Hi,

Using getElementByTagName by selecting elements prefixed with namespaces ("stream:features", "stream:error") don't work in several browsers like Chrome or Safari (but it works in Firefox)

Replacing getElementByTagName calls with getElementByTagNameNS in those lines where you want to find prefixed namespaced elements solves the issue and you don't have to first check `getElementsByTagName("stream:features")` and then `getElementsByTagName("features")`

If you accept this patch, [strophejs-bower](https://github.com/strophe/strophejs-bower) repository should be updated too :-)
Cheers
