### PR TITLE
Update docs for addHandler (highlight return val)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2092,8 +2092,8 @@ Strophe.Connection.prototype = {
      *  they must all match for the handler to be invoked.
      *
      *  The handler will receive the stanza that triggered it as its argument.
-     *  The handler should return true if it is to be invoked again;
-     *  returning false will remove the handler after it returns.
+     *  *The handler should return true if it is to be invoked again;
+     *  returning false will remove the handler after it returns.*
      *
      *  As a convenience, the ns parameters applies to the top level element
      *  and also any of its immediate children.  This is primarily to make


### PR DESCRIPTION
Various people new to Strophe.js are still struggling with the fact that no return value in a callback will remove the handler and isn't invoked again. 
Hopefully this doc improvement will eliminate questions like this.