### PR TITLE
The queue data was not reset during the .reset()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1635,6 +1635,7 @@ Strophe.Connection.prototype = {
         this.disconnecting = false;
         this.connected = false;
 
+        this._data = [];
         this._requests = [];
         this._uniqueId = 0;
     },


### PR DESCRIPTION
of the connection, making the first request when reconnecting to contains also
these unwanted data