### PR TITLE
When sending na IQ we need the resulting iq only when its type is 'result' or 'error'.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1948,7 +1948,7 @@ Strophe.Connection.prototype = {
         var expectedFrom = elem.getAttribute("to");
         var fulljid = this.jid;
 
-        var handler = this.addHandler(function (stanza) {
+        var handlerFunc = function (stanza) {
             // remove timeout handler if there is one
             if (timeoutHandler) {
                 that.deleteTimedHandler(timeoutHandler);
@@ -1987,20 +1987,26 @@ Strophe.Connection.prototype = {
                     message: "Got bad IQ type of " + iqtype
                 };
             }
-        }, null, 'iq', null, id);
+        };
 
-        // if timeout specified, setup timeout handler.
-        if (timeout) {
-            timeoutHandler = this.addTimedHandler(timeout, function () {
-                // get rid of normal handler
-                that.deleteHandler(handler);
+        // when sending iq the result is an iq with same id and type of result or error
+        var handlerResult = this.addHandler(handlerFunc, null, 'iq', 'result', id);
+        var handlerError = this.addHandler(handlerFunc, null, 'iq', 'error', id);
 
-                // call errback on timeout with null stanza
-                if (errback) {
-                    errback(null);
-                }
-                return false;
-            });
+        for(handler in [handlerResult, handlerError]) {
+            // if timeout specified, setup timeout handler.
+            if (timeout) {
+                timeoutHandler = this.addTimedHandler(timeout, function () {
+                    // get rid of normal handler
+                    that.deleteHandler(handler);
+
+                    // call errback on timeout with null stanza
+                    if (errback) {
+                        errback(null);
+                    }
+                    return false;
+                });
+            }
         }
 
         this.send(elem);


### PR DESCRIPTION
When sending an IQ we need the resulting iq only when its type is 'result' or 'error'. Fixes a problem where it is possible server to use the same id to send us an iq packet with type 'get' and Strophe crashes with error 'Strophe: error: Got bad IQ type of get undefined'.