### PR TITLE
Support for websockets in Prosody 0.10

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Strophe.js Basic Example</title>
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js'></script>
+    <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js'></script>
     <script src='../strophe.js'></script>
     <script src='basic.js'></script>
   </head>

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -253,6 +253,8 @@ Strophe.Websocket.prototype = {
             this._conn._changeConnectStatus(Strophe.Status.CONNFAIL, "Received closing stream");
             this._conn._doDisconnect();
             return;
+        } else if (message.data.indexOf("<open ") === 0){
+          // nop
         } else {
             var string = this._streamWrap(message.data);
             var elem = new DOMParser().parseFromString(string, "text/xml").documentElement;
@@ -305,6 +307,10 @@ Strophe.Websocket.prototype = {
      */
     _streamWrap: function (stanza)
     {
+        if (this.streamStart === undefined){
+          // streamStart is not set. Therefore, the xmpp server does not wrap messages in a "<stream>" tag
+          this.streamStart = "<stream:stream xmlns:stream='http://etherx.jabber.org/streams'>";
+        }
         return this.streamStart + stanza + '</stream:stream>';
     },
 


### PR DESCRIPTION
  Support for websockets in Prosody 0.10
- I do not think that this will break support for any other websocket implementation, I did not test it though

Changed references to JQuery to the https protocol, because using http will lead to errors in chrome when you are connected via https
  - See info to [https://developer.mozilla.org/en-US/docs/Security/MixedContent](Mixed Content)