### PR TITLE
Fixed IE9 compatibility

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2386,7 +2386,10 @@ Strophe.Connection.prototype = {
         this._authentication.legacy_auth = false;
 
         // Check for the stream:features tag
-        var hasFeatures = bodyWrap.getElementsByTagNameNS(Strophe.NS.STREAM, "features").length > 0;
+        var hasFeatures = bodyWrap.getElementsByTagName("stream:features").length > 0;
+        if (!hasFeatures) {
+            hasFeatures = bodyWrap.getElementsByTagName("features").length > 0;
+        }
         var mechanisms = bodyWrap.getElementsByTagName("mechanism");
         var matched = [];
         var i, mech, found_authentication = false;


### PR DESCRIPTION
I get this error in IE9:

![screen shot 2015-03-26 at 15 20 12](https://cloud.githubusercontent.com/assets/935744/6848126/af0d5edc-d3cb-11e4-9a99-c7381a819ca6.png)

According to https://msdn.microsoft.com/en-us/library/ie/ff975218%28v=vs.85%29.aspx getElementsByTagNameNS is supported on IE9 so I guess that there's something wrong with the bodyWrap object.

Any ideas? I'm just reverting to a previous version implementation of `hasFeatures`.

