### PR TITLE
Session handling

### DIFF
--- a/examples/restore.html
+++ b/examples/restore.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <!-- Session caching and restoring example. -->
+
+  <head>
+    <title>Strophe.js Persistent Session Example</title>
+    <script src="../main.js"></script>
+	<script src="../bower_components/requirejs/require.js" data-main="restore.js"></script>
+  </head>
+
+  <body>
+    <div id='login' style='text-align: center'>
+      <form name='cred'>
+        <label for='jid'>JID:</label>
+        <input type='text' id='jid'>
+        <label for='pass'>Password:</label>
+        <input type='password' id='pass'>
+        <input type='button' id='connect' value='connect'>
+      </form>
+    </div>
+    <hr>
+    <div id='log'></div>
+  </body>
+</html>

--- a/examples/restore.js
+++ b/examples/restore.js
@@ -1,0 +1,71 @@
+config.baseUrl = '../';
+require.config(config);
+if (typeof(require) === 'function') {
+    require(["jquery", "strophe", ], function($, wrapper) {
+        Strophe = wrapper.Strophe;
+
+        var button = document.getElementById("connect");
+        button.addEventListener('click', function () {
+            if (button.value == 'connect') {
+                button.value = 'disconnect';
+                connection.connect(
+                    $('#jid').get(0).value,
+                    $('#pass').get(0).value,
+                    onConnect
+                );
+            } else {
+                button.value = 'connect';
+                connection.disconnect();
+            }
+        });
+        $(button).hide();
+
+        var BOSH_SERVICE = 'https://conversejs.org/http-bind/';
+        var connection = null;
+
+        function log(msg) {
+            $('#log').append('<div></div>').append(document.createTextNode(msg));
+        }
+
+        function rawInput(data) {
+            log('RECV: ' + data);
+        }
+
+        function rawOutput(data) {
+            log('SENT: ' + data);
+        }
+
+        function onConnect(status) {
+            if (status == Strophe.Status.CONNECTING) {
+                log('Strophe is connecting.');
+            } else if (status == Strophe.Status.CONNFAIL) {
+                log('Strophe failed to connect.');
+                $('#connect').get(0).value = 'connect';
+            } else if (status == Strophe.Status.DISCONNECTING) {
+                log('Strophe is disconnecting.');
+            } else if (status == Strophe.Status.DISCONNECTED) {
+                log('Strophe is disconnected.');
+                $('#connect').get(0).value = 'connect';
+            } else if (status == Strophe.Status.CONNECTED) {
+                log('Strophe is connected.');
+            } else if (status == Strophe.Status.ATTACHED) {
+                log('Strophe is attached.');
+                var button = $('#connect').get(0);
+                button.value = 'disconnect';
+                $(button).show();
+            }
+        }
+
+        $(document).ready(function () {
+            connection = new Strophe.Connection(BOSH_SERVICE, {'keepalive': true});
+            connection.rawInput = rawInput;
+            connection.rawOutput = rawOutput;
+            try {
+                connection.restore(null, onConnect);
+            } catch(e) {
+                if (e.name !== "StropheSessionError") { throw(e); }
+                $(button).show();
+            }
+        });
+    });
+}

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -324,6 +324,7 @@ Strophe.Bosh.prototype = {
     {
         var session = JSON.parse(window.sessionStorage.getItem('strophe-bosh-session'));
         if (typeof session !== "undefined" && session !== null && session.rid && session.sid && session.jid) {
+            this._conn.restored = true;
             this._attach(session.jid, session.sid, session.rid, callback, wait, hold, wind);
         } else {
             throw { name: "StropheSessionError", message: "_restore: no restoreable session." };

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -215,6 +215,7 @@ Strophe.Bosh.prototype = {
         this.rid = Math.floor(Math.random() * 4294967295);
         this.sid = null;
         this.errors = 0;
+        window.sessionStorage.removeItem('strophe-bosh-session');
     },
 
     /** PrivateFunction: _connect
@@ -300,6 +301,57 @@ Strophe.Bosh.prototype = {
         this._conn._changeConnectStatus(Strophe.Status.ATTACHED, null);
     },
 
+    /** PrivateFunction: _restore
+     *  Attempt to restore a cached BOSH session
+     *
+     *  Parameters:
+     *    (String) jid - The full JID that is bound by the session.
+     *      This parameter is optional but recommended, specifically in cases
+     *      where prebinded BOSH sessions are used where it's important to know
+     *      that the right session is being restored.
+     *    (Function) callback The connect callback function.
+     *    (Integer) wait - The optional HTTPBIND wait value.  This is the
+     *      time the server will wait before returning an empty result for
+     *      a request.  The default setting of 60 seconds is recommended.
+     *      Other settings will require tweaks to the Strophe.TIMEOUT value.
+     *    (Integer) hold - The optional HTTPBIND hold value.  This is the
+     *      number of connections the server will hold at one time.  This
+     *      should almost always be set to 1 (the default).
+     *    (Integer) wind - The optional HTTBIND window value.  This is the
+     *      allowed range of request ids that are valid.  The default is 5.
+     */
+    _restore: function (jid, callback, wait, hold, wind)
+    {
+        var session = JSON.parse(window.sessionStorage.getItem('strophe-bosh-session'));
+        if (typeof session !== "undefined" && session !== null && session.rid && session.sid && session.jid) {
+            this._attach(session.jid, session.sid, session.rid, callback, wait, hold, wind);
+        } else {
+            throw { name: "StropheSessionError", message: "_restore: no restoreable session." };
+        }
+    },
+
+    /** PrivateFunction: _cacheSession
+     *  _Private_ handler for the beforeunload event.
+     *
+     *  This handler is used to process the Bosh-part of the initial request.
+     *  Parameters:
+     *    (Strophe.Request) bodyWrap - The received stanza.
+     */
+    _cacheSession: function ()
+    {
+        if (this._conn.connected) {
+            if (this._conn.jid && this.rid && this.sid) {
+                window.sessionStorage.setItem('strophe-bosh-session', JSON.stringify({
+                    'jid': this._conn.jid,
+                    'rid': this.rid,
+                    'sid': this.sid
+                }));
+            }
+        } else {
+            window.sessionStorage.removeItem('strophe-bosh-session');
+        }
+    },
+
     /** PrivateFunction: _connect_cb
      *  _Private_ handler for initial connection request.
      *
@@ -361,6 +413,7 @@ Strophe.Bosh.prototype = {
     {
         this.sid = null;
         this.rid = Math.floor(Math.random() * 4294967295);
+        window.sessionStorage.removeItem('strophe-bosh-session');
     },
 
     /** PrivateFunction: _emptyQueue

--- a/src/core.js
+++ b/src/core.js
@@ -1563,12 +1563,12 @@ Strophe.Connection = function (service, options)
     this._idleTimeout = null;
     this._disconnectTimeout = null;
 
-    this.do_authentication = true;
     this.authenticated = false;
-    this.disconnecting = false;
     this.connected = false;
-
+    this.disconnecting = false;
+    this.do_authentication = true;
     this.paused = false;
+    this.restored = false;
 
     this._data = [];
     this._uniqueId = 0;
@@ -1621,8 +1621,9 @@ Strophe.Connection.prototype = {
         this._authentication = {};
 
         this.authenticated = false;
-        this.disconnecting = false;
         this.connected = false;
+        this.disconnecting = false;
+        this.restored = false;
 
         this._data = [];
         this._requests = [];
@@ -1738,6 +1739,7 @@ Strophe.Connection.prototype = {
         this.disconnecting = false;
         this.connected = false;
         this.authenticated = false;
+        this.restored = false;
 
         // parse jid for domain
         this.domain = Strophe.getDomainFromJid(this.jid);
@@ -2305,6 +2307,7 @@ Strophe.Connection.prototype = {
 
         this.authenticated = false;
         this.disconnecting = false;
+        this.restored = false;
 
         // delete handlers
         this.handlers = [];

--- a/src/core.js
+++ b/src/core.js
@@ -1443,7 +1443,7 @@ Strophe.TimedHandler.prototype = {
  *  The user will also have several event handlers defined by using
  *  addHandler() and addTimedHandler().  These will allow the user code to
  *  respond to interesting stanzas or do something periodically with the
- *  connection.  These handlers will be active once authentication is
+ *  connection. These handlers will be active once authentication is
  *  finished.
  *
  *  To send data to the connection, use send().
@@ -1481,10 +1481,11 @@ Strophe.TimedHandler.prototype = {
  *
  *  BOSH options:
  *
- *  by adding "sync" to the options, you can control if requests will
+ *  By adding "sync" to the options, you can control if requests will
  *  be made synchronously or not. The default behaviour is asynchronous.
  *  If you want to make requests synchronous, make "sync" evaluate to true:
  *  > var conn = new Strophe.Connection("/http-bind/", {sync: true});
+ *
  *  You can also toggle this on an already established connection:
  *  > conn.options.sync = true;
  *
@@ -1746,7 +1747,15 @@ Strophe.Connection.prototype = {
      */
     attach: function (jid, sid, rid, callback, wait, hold, wind)
     {
-        this._proto._attach(jid, sid, rid, callback, wait, hold, wind);
+        if (this._proto instanceof Strophe.Bosh) {
+            this._proto._attach(jid, sid, rid, callback, wait, hold, wind);
+        } else {
+            throw {
+                name: 'StropheSessionError',
+                message: 'The "attach" method can only be used with a BOSH connection.'
+            };
+        }
+    },
     },
 
     /** Function: xmlInput

--- a/src/core.js
+++ b/src/core.js
@@ -1495,9 +1495,9 @@ Strophe.TimedHandler.prototype = {
  *  The "keepalive" option can be used to instruct Strophe to maintain the
  *  current BOSH session across interruptions such as webpage reloads.
  *
- *  It will do this by caching the sessions tokens, and when "connect" is
- *  called it will check whether there are cached tokens with which it can
- *  resume an existing session.
+ *  It will do this by caching the sessions tokens in sessionStorage, and when
+ *  "restore" is called it will check whether there are cached tokens with
+ *  which it can resume an existing session.
  *
  *  Parameters:
  *    (String) service - The BOSH or WebSocket service URL.

--- a/src/core.js
+++ b/src/core.js
@@ -1430,9 +1430,9 @@ Strophe.TimedHandler.prototype = {
 /** Class: Strophe.Connection
  *  XMPP Connection manager.
  *
- *  This class is the main part of Strophe.  It manages a BOSH connection
- *  to an XMPP server and dispatches events to the user callbacks as
- *  data arrives.  It supports SASL PLAIN, SASL DIGEST-MD5, SASL SCRAM-SHA1
+ *  This class is the main part of Strophe.  It manages a BOSH or websocket
+ *  connection to an XMPP server and dispatches events to the user callbacks
+ *  as data arrives. It supports SASL PLAIN, SASL DIGEST-MD5, SASL SCRAM-SHA1
  *  and legacy authentication.
  *
  *  After creating a Strophe.Connection object, the user will typically
@@ -1489,6 +1489,15 @@ Strophe.TimedHandler.prototype = {
  *  You can also toggle this on an already established connection:
  *  > conn.options.sync = true;
  *
+ *  The "customHeaders" option can be used to provide custom HTTP headers to be
+ *  included in the XMLHttpRequests made.
+ *
+ *  The "keepalive" option can be used to instruct Strophe to maintain the
+ *  current BOSH session across interruptions such as webpage reloads.
+ *
+ *  It will do this by caching the sessions tokens, and when "connect" is
+ *  called it will check whether there are cached tokens with which it can
+ *  resume an existing session.
  *
  *  Parameters:
  *    (String) service - The BOSH or WebSocket service URL.
@@ -1513,6 +1522,11 @@ Strophe.Connection = function (service, options)
     } else {
         this._proto = new Strophe.Bosh(this);
     }
+
+    if (options.keepalive && this._proto instanceof Strophe.Bosh) {
+        window.addEventListener("beforeunload", this._proto._cacheSession.bind(this._proto), false);
+    }
+
     /* The connected JID. */
     this.jid = "";
     /* the JIDs domain */
@@ -1756,6 +1770,61 @@ Strophe.Connection.prototype = {
             };
         }
     },
+
+    /** Function: restore
+     *  Attempt to restore a cached BOSH session.
+     *
+     *  This function is only useful in conjunction with providing the
+     *  "keepalive":true option when instantiating a new Strophe.Connection.
+     *
+     *  When "keepalive" is set to true, Strophe will cache the BOSH tokens
+     *  RID (Request ID) and SID (Session ID) and then when this function is
+     *  called, it will attempt to restore the session from those cached
+     *  tokens.
+     *
+     *  This function must therefore be called instead of connect or attach.
+     *
+     *  Parameters:
+     *    (String) jid - The user's JID.  This may be a bare JID or a full JID.
+     *    (Function) callback - The connect callback function.
+     *    (Integer) wait - The optional HTTPBIND wait value.  This is the
+     *      time the server will wait before returning an empty result for
+     *      a request.  The default setting of 60 seconds is recommended.
+     *    (Integer) hold - The optional HTTPBIND hold value.  This is the
+     *      number of connections the server will hold at one time.  This
+     *      should almost always be set to 1 (the default).
+     *    (Integer) wind - The optional HTTBIND window value.  This is the
+     *      allowed range of request ids that are valid.  The default is 5.
+     */
+    restore: function (jid, callback, wait, hold, wind)
+    {
+        if (this._sessionCachingSupported) {
+            this._proto._restore(jid, callback, wait, hold, wind);
+        } else {
+            throw {
+                name: 'StropheSessionError',
+                message: 'The "restore" method can only be used with a BOSH connection.'
+            };
+        }
+    },
+
+    /** PrivateFunction: _sessionCachingSupported
+     * Checks whether sessionStorage and JSON are supported and whether we're
+     * using BOSH.
+     */
+    _sessionCachingSupported: function ()
+    {
+        if (this._proto instanceof Strophe.Bosh) {
+            if (!JSON) { return false; }
+            try {
+                window.sessionStorage.setItem('_strophe_', '_strophe_');
+                window.sessionStorage.removeItem('_strophe_');
+            } catch (e) {
+                return false;
+            }
+            return true;
+        }
+        return false;
     },
 
     /** Function: xmlInput

--- a/src/core.js
+++ b/src/core.js
@@ -1800,7 +1800,7 @@ Strophe.Connection.prototype = {
      */
     restore: function (jid, callback, wait, hold, wind)
     {
-        if (this._sessionCachingSupported) {
+        if (this._sessionCachingSupported()) {
             this._proto._restore(jid, callback, wait, hold, wind);
         } else {
             throw {

--- a/src/core.js
+++ b/src/core.js
@@ -1523,7 +1523,7 @@ Strophe.Connection = function (service, options)
         this._proto = new Strophe.Bosh(this);
     }
 
-    if (options.keepalive && this._proto instanceof Strophe.Bosh) {
+    if (this.options.keepalive && this._proto instanceof Strophe.Bosh) {
         window.addEventListener("beforeunload", this._proto._cacheSession.bind(this._proto), false);
     }
 
@@ -1783,6 +1783,8 @@ Strophe.Connection.prototype = {
      *  tokens.
      *
      *  This function must therefore be called instead of connect or attach.
+     *
+     *  For an example on how to use it, please see examples/restore.js
      *
      *  Parameters:
      *    (String) jid - The user's JID.  This may be a bare JID or a full JID.

--- a/src/core.js
+++ b/src/core.js
@@ -1536,7 +1536,15 @@ Strophe.Connection = function (service, options)
     }
 
     if (this.options.keepalive && this._proto instanceof Strophe.Bosh) {
-        window.addEventListener("beforeunload", this._proto._cacheSession.bind(this._proto), false);
+        if ('onbeforeunload' in window) {
+            window.addEventListener("beforeunload", this._proto._cacheSession.bind(this._proto), false);
+        } else if ('onunload' in window) {
+            window.addEventListener("unload", this._proto._cacheSession.bind(this._proto), false);
+        } else if ('onpagehide' in window) {
+            // Mobile Safari (at least older versions) doesn't support unload or beforeunload.
+            // Apple recommends "pagehide" instead.
+            window.addEventListener("pagehide", this._proto._cacheSession.bind(this._proto), false);
+        }
     }
 
     /* The connected JID. */

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -417,6 +417,7 @@ define([
 			var conn = new Strophe.Connection("");
 			var boshSpy = sinon.spy(conn._proto, "_restore");
 			var checkSpy = sinon.spy(conn, "_sessionCachingSupported");
+            equal(conn.restored, false);
 			try {
 				conn.restore();
 			} catch (e) {
@@ -437,18 +438,22 @@ define([
 				equal(e.message, 'The "restore" method can only be used with a BOSH connection.',
 				    'The conn.restore method can only be used with a BOSH connection.');
 			}
+            equal(conn.restored, false);
 		});
 
         test('when calling "restore" without a restorable session, an exception is raised', function () {
+            window.sessionStorage.removeItem('strophe-bosh-session');
 			var conn = new Strophe.Connection("", {"keepalive": true});
 			var boshSpy = sinon.spy(conn._proto, "_restore");
 			var checkSpy = sinon.spy(conn, "_sessionCachingSupported");
+            equal(conn.restored, false);
 			try {
 				conn.restore();
 			} catch (e) {
 				equal(e.name, "StropheSessionError");
 				equal(e.message, "_restore: no restoreable session.");
             }
+            equal(conn.restored, false);
             equal(boshSpy.called, true);
             equal(checkSpy.called, true);
         });
@@ -477,11 +482,13 @@ define([
             conn._proto.rid = '123456';
             conn._proto.sid = '987654321';
             conn._proto._cacheSession();
+            equal(conn.restored, false);
 
 			var boshSpy = sinon.spy(conn._proto, "_restore");
 			var checkSpy = sinon.spy(conn, "_sessionCachingSupported");
             var attachSpsy = sinon.spy(conn._proto, "_attach");
             conn.restore();
+            equal(conn.restored, true);
             equal(boshSpy.called, true);
             equal(checkSpy.called, true);
             equal(attachSpsy.called, true);


### PR DESCRIPTION
The "keepalive" option can be used to instruct Strophe to maintain the current BOSH session across interruptions such as webpage reloads. 

It will do this by caching the sessions tokens in sessionStorage, and when `connection.restore` is called it will check whether there are cached tokens with which it can resume an existing session.

This is how you would use it:

```javascript
    var connection = new Strophe.Connection(BOSH_SERVICE, {'keepalive': true});
    try {
        connection.restore(jid, callback);
    } catch(e) {
        if (e.name !== "StropheSessionError") { throw(e); }
        # Make ajax call to get new BOSH session tokens and then attach with
        # connection.attach
    }                                                                                                                     
```

When creating prebound BOSH sessions server-side, it's important to pass in the JID to the `connection.restore` method. Otherwise one might get sessions restored for the wrong users.

In the manual login case, it's not necessary to pass in the JID.
