### PR TITLE
 [WIP] add ridChange function

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -218,7 +218,7 @@ Strophe.Bosh.prototype = {
         this.errors = 0;
         window.sessionStorage.removeItem('strophe-bosh-session');
 
-        this._conn.ridChange(this.rid);
+        this._conn.nextValidRid(this.rid);
     },
 
     /** PrivateFunction: _connect
@@ -425,7 +425,7 @@ Strophe.Bosh.prototype = {
         this.rid = Math.floor(Math.random() * 4294967295);
         window.sessionStorage.removeItem('strophe-bosh-session');
 
-        this._conn.ridChange(this.rid);
+        this._conn.nextValidRid(this.rid);
     },
 
     /** PrivateFunction: _emptyQueue
@@ -637,7 +637,7 @@ Strophe.Bosh.prototype = {
                     this._restartRequest(0);
                 }
 
-                this._conn.ridChange(Number(req.rid) + 1);
+                this._conn.nextValidRid(Number(req.rid) + 1);
 
                 // call handler
                 Strophe.debug("request id " +

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -217,6 +217,8 @@ Strophe.Bosh.prototype = {
         this.sid = null;
         this.errors = 0;
         window.sessionStorage.removeItem('strophe-bosh-session');
+
+        this._conn.ridChange(this.rid);
     },
 
     /** PrivateFunction: _connect
@@ -422,6 +424,8 @@ Strophe.Bosh.prototype = {
         this.sid = null;
         this.rid = Math.floor(Math.random() * 4294967295);
         window.sessionStorage.removeItem('strophe-bosh-session');
+
+        this._conn.ridChange(this.rid);
     },
 
     /** PrivateFunction: _emptyQueue
@@ -632,6 +636,9 @@ Strophe.Bosh.prototype = {
                      this._requests[0].age() > Math.floor(Strophe.SECONDARY_TIMEOUT * this.wait))) {
                     this._restartRequest(0);
                 }
+
+                this._conn.ridChange(Number(req.rid) + 1);
+
                 // call handler
                 Strophe.debug("request id " +
                               req.id + "." +

--- a/src/core.js
+++ b/src/core.js
@@ -1933,6 +1933,24 @@ Strophe.Connection.prototype = {
     },
     /* jshint unused:true */
 
+    /** Function: ridChange
+     *  User overrideable function that receives the new rid.
+     *
+     *  The default function does nothing. User code can override this with
+     *  > Strophe.Connection.ridChange = function (rid) {
+     *  >    (user code)
+     *  > };
+     *
+     *  Parameters:
+     *    (Number) rid - The current rid
+     */
+    /* jshint unused:false */
+    ridChange: function (rid)
+    {
+        return;
+    },
+    /* jshint unused:true */
+
     /** Function: send
      *  Send a stanza.
      *

--- a/src/core.js
+++ b/src/core.js
@@ -1933,19 +1933,19 @@ Strophe.Connection.prototype = {
     },
     /* jshint unused:true */
 
-    /** Function: ridChange
-     *  User overrideable function that receives the new rid.
+    /** Function: nextValidRid
+     *  User overrideable function that receives the new valid rid.
      *
      *  The default function does nothing. User code can override this with
-     *  > Strophe.Connection.ridChange = function (rid) {
+     *  > Strophe.Connection.nextValidRid = function (rid) {
      *  >    (user code)
      *  > };
      *
      *  Parameters:
-     *    (Number) rid - The current rid
+     *    (Number) rid - The next valid rid
      */
     /* jshint unused:false */
-    ridChange: function (rid)
+    nextValidRid: function (rid)
     {
         return;
     },


### PR DESCRIPTION
As discussed in #133, I added a <code>ridChange</code> function to the Connection prototype. But I am not sure, if this is the proper place, or if this should be an option.

Also some tests are missing, but I could not run the tests:

```
$ grunt test
Running "connect:server" (connect) task
Started connect web server on http://0.0.0.0:8000

Running "qunit:all" (qunit) task
Testing http://localhost:8000/tests/strophe.html 
>> PhantomJS timed out, possibly due to a missing QUnit start() call.
Warning: 1/1 assertions failed (0ms) Use --force to continue.

Aborted due to warnings.
```

Do you have any idea, how to solve this?