### PR TITLE
Improve support for AMD when loading compiled strophe.js

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.min.js binary

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function(grunt){
 
         concat: {
             dist: {
-                src: ['src/wrap_header.js', 'src/base64.js', 'src/sha1.js', 'src/md5.js', 'src/polyfills.js', 'src/core.js', 'src/bosh.js', 'src/websocket.js', 'src/wrap_footer.js'],
+                src: ['src/wrap_header.js', 'src/base64.js', 'src/sha1.js', 'src/md5.js', 'src/polyfills.js', 'src/core.js', 'src/bosh.js', 'src/websocket.js', 'src/wrapper.js', 'src/wrap_footer.js'],
                 dest: '<%= pkg.name %>'
             },
             options: {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -6,6 +6,18 @@
 */
 
 /* jshint undef: true, unused: true:, noarg: true, latedef: true */
+/* global define */
+
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define('strophe-polyfill', [], function () {
+            return factory();
+        });
+    } else {
+        // Browser globals
+        return factory();
+    }
+}(this, function () {
 
 /** PrivateFunction: Function.prototype.bind
  *  Bind a function to an instance.
@@ -88,3 +100,4 @@ if (!Array.prototype.indexOf)
             return -1;
         };
     }
+}));

--- a/src/wrap_footer.js
+++ b/src/wrap_footer.js
@@ -1,6 +1,14 @@
 /* jshint ignore:start */
 if (callback) {
-    return callback(Strophe, $build, $msg, $iq, $pres);
+    if(typeof define === 'function' && define.amd){
+        //For backwards compatability
+        var n_callback = callback;
+        require(["strophe"],function(o){
+            n_callback(o.Strophe,o.$build,o.$msg,o.$iq,o.$pres);
+        });
+    }else{
+        return callback(Strophe, $build, $msg, $iq, $pres);
+    }
 }
 
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,7 +1,11 @@
-define("strophe", [
-    "strophe-core",
-    "strophe-bosh",
-    "strophe-websocket"
-], function (wrapper) {
-    return wrapper;
-});
+(function(root){
+    if(typeof define === 'function' && define.amd){
+        define("strophe", [
+            "strophe-core",
+            "strophe-bosh",
+            "strophe-websocket"
+        ], function (wrapper) {
+            return wrapper;
+        });
+    }
+})(this);


### PR DESCRIPTION
When strophe.js is compiled, then imported into another project with a loader such as RequireJS, callback at [strophe.js:5512](https://github.com/strophe/strophejs/blob/a11ebefa3db1b6712d51d0d309b9f68f8e391d1b/strophe.js#L5512) fails since the variables (`Strophe`, `$build`, `$msg`, `$iq`, and `$pres`) are no longer defined in the scope. The wrapper used to link all the sub modules wasn't included, so the script was broken entirely.

This isn't particulary helpful when using CDN hosted scripts such as [CDNJS](https://cdnjs.com/libraries/strophe.js)

This commit addresses the broken AMD support while preserving the use of the script otherwise