### PR TITLE
Added new value (CONNTIMEOUT) to Strophe.Status

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -220,6 +220,7 @@ Strophe = {
      *  Status.DISCONNECTED - The connection has been terminated
      *  Status.DISCONNECTING - The connection is currently being terminated
      *  Status.ATTACHED - The connection has been attached
+     *  Status.CONNTIMEOUT - The connection has timed out
      */
     Status: {
         ERROR: 0,
@@ -231,7 +232,8 @@ Strophe = {
         DISCONNECTED: 6,
         DISCONNECTING: 7,
         ATTACHED: 8,
-        REDIRECT: 9
+        REDIRECT: 9,
+        CONNTIMEOUT: 10
     },
 
     /** Constants: Log Level Constants
@@ -3034,6 +3036,8 @@ Strophe.Connection.prototype = {
     _onDisconnectTimeout: function ()
     {
         Strophe.info("_onDisconnectTimeout was called");
+
+        this._changeConnectStatus(Strophe.Status.CONNTIMEOUT, null);
 
         this._proto._onDisconnectTimeout();
 


### PR DESCRIPTION
This new value serves to notify the user that the connection has timed out, which can be useful to the UI of some clients.

In some cases, when a conneciton times out, the connection goes from CONNECTED to DISCONNECTED without informing the upper layers, this can be fixed with a workaround but it would be much nicer if the connection itself notified this change of state. I followed up the convention used to name CONNFAIL.