### PR TITLE
bosh: check sessionStorage support before using it

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -198,7 +198,7 @@ Strophe.Bosh.prototype = {
         if (this.sid !== null) {
             bodyWrap.attrs({sid: this.sid});
         }
-        if (this._conn.options.keepalive) {
+        if (this._conn.options.keepalive && this._conn._sessionCachingSupported()) {
             this._cacheSession();
         }
         return bodyWrap;
@@ -214,7 +214,9 @@ Strophe.Bosh.prototype = {
         this.rid = Math.floor(Math.random() * 4294967295);
         this.sid = null;
         this.errors = 0;
-        window.sessionStorage.removeItem('strophe-bosh-session');
+        if (this._conn._sessionCachingSupported()) {
+            window.sessionStorage.removeItem('strophe-bosh-session');
+        }
 
         this._conn.nextValidRid(this.rid);
     },
@@ -421,7 +423,9 @@ Strophe.Bosh.prototype = {
     {
         this.sid = null;
         this.rid = Math.floor(Math.random() * 4294967295);
-        window.sessionStorage.removeItem('strophe-bosh-session');
+        if (this._conn._sessionCachingSupported()) {
+            window.sessionStorage.removeItem('strophe-bosh-session');
+        }
 
         this._conn.nextValidRid(this.rid);
     },


### PR DESCRIPTION
Before, only Connection.restore() tried to check if caching a session (using
window.sessionStorage) is supported. Unfortunately, other functions in Bosh
tried to use window.sessionStorage without checking. It meant that sometimes
window.sessionStorage.removeItem() would fail and e.g. disconnect handlers
wouldn't be called.

In practice, access control to window.sessionStorage can be buried deep in
browser settings and it could be very tricky to figure out why users can't log
out cleanly when they're using BOSH. Example: setting 3rd-party cookies option
to "ask" in Firefox makes it so that every usage of window.sessionStorage
results in a SecurityError: The operation is insecure.