### PR TITLE
Fix .c() to accept both text and numbers as text for the child element.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1116,7 +1116,7 @@ Strophe.Builder.prototype = {
     c: function (name, attrs, text) {
         var child = Strophe.xmlElement(name, attrs, text);
         this.node.appendChild(child);
-        if (typeof text !== "string") {
+        if (typeof text !== "string" && typeof text !=="number") {
             this.node = child;
         }
         return this;


### PR DESCRIPTION
This bid me so hard :) Used to behave nicely before (was using 1.1.5 iirc) but broke somewhere in between.

I changed ``.c()`` to accept both numbers and text as text content of the child node.
Note that this is consistent with ``Strophe.xmlElement`` which is called to create the node and accepts both numbers and text.