### PR TITLE
Fix bower dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,11 +29,11 @@
     "tests"
   ],
   "devDependencies": {
-    "sinon": "http://sinonjs.org/releases/sinon-1.12.2.js",
+    "sinon": "http://sinonjs.org/releases/sinon-1.17.3.js",
     "sinon-qunit": "~2.0.0",
     "qunit": "~1.16.0",
-    "jquery": "1.11.0",
-    "requirejs": "~2.1.15",
+    "jquery": "2.2.4",
+    "requirejs": "~2.2.0",
     "almond": "~0.3.0"
   },
   "moduleType": [

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "examples",
     "tests"
   ],
-  "dependencies": {
+  "devDependencies": {
     "sinon": "http://sinonjs.org/releases/sinon-1.12.2.js",
     "sinon-qunit": "~2.0.0",
     "qunit": "~1.16.0",


### PR DESCRIPTION
Moves dependencies to be devDependencies in bower. This allows to install strophe without bringing over sinon and all the rest and having to resolve conflicts.
I also took the liberty to update the bower versions, tests pass but if there is a reason to be running jquery 1.* feel free to revert.