### PR TITLE
User requirejs instead of require for node compat

### DIFF
--- a/src/wrap_footer.js
+++ b/src/wrap_footer.js
@@ -3,7 +3,7 @@ if (callback) {
     if(typeof define === 'function' && define.amd){
         //For backwards compatability
         var n_callback = callback;
-        require(["strophe"],function(o){
+        requirejs(["strophe"],function(o){
             n_callback(o.Strophe,o.$build,o.$msg,o.$iq,o.$pres);
         });
     }else{


### PR DESCRIPTION
Hopefully I caught it before release :)
Using ``requirejs`` instead of ``require`` allows strophe to use require in mixed node/browser environments such as electron apps.
