### PR TITLE
Allow custom Content-Type header for requests

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -718,8 +718,9 @@ Strophe.Bosh.prototype = {
                           "." + req.sends + " posting");
 
             try {
+                var contentType = this._conn.options.contentType || "text/xml; charset=utf-8";
                 req.xhr.open("POST", this._conn.service, this._conn.options.sync ? false : true);
-                req.xhr.setRequestHeader("Content-Type", "text/xml; charset=utf-8");
+                req.xhr.setRequestHeader("Content-Type", contentType);
                 if (this._conn.options.withCredentials) {
                     req.xhr.withCredentials = true;
                 }

--- a/src/core.js
+++ b/src/core.js
@@ -1518,6 +1518,10 @@ Strophe.TimedHandler.prototype = {
  *  Access-Control-Allow-Origin header can't be set to the wildcard "*", but
  *  instead must be restricted to actual domains.
  *
+ *  The "contentType" option can be set to change the default Content-Type
+ *  of "text/xml; charset=utf-8", which can be useful to reduce the amount of
+ *  CORS preflight requests that are sent to the server.
+ *
  *  Parameters:
  *    (String) service - The BOSH or WebSocket service URL.
  *    (Object) options - A hash of configuration options

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -161,6 +161,33 @@ define([
             timeoutStub.restore();
         });
 
+        test("content type can be set on the XMLHttpRequest object", function () {
+            var stanza = $pres();
+            // Stub XMLHttpRequest.protototype.send so that it doesn't
+            // actually try to send out the request.
+            var sendStub = sinon.stub(XMLHttpRequest.prototype, "send");
+            // Stub setTimeout to immediately call functions, otherwise our
+            // assertions fail due to async execution.
+            var timeoutStub = sinon.stub(window, "setTimeout", function (func) {
+                func.apply(arguments);
+            });
+            var setRetRequestHeaderStub = sinon.stub(XMLHttpRequest.prototype, "setRequestHeader");
+            var conn = new Strophe.Connection("example.org");
+            conn.send(stanza);
+            equal(setRetRequestHeaderStub.getCalls()[0].args[0], "Content-Type");
+            equal(setRetRequestHeaderStub.getCalls()[0].args[1], "text/xml; charset=utf-8");
+
+            conn = new Strophe.Connection(
+                    "example.org",
+                    { contentType: "text/plain; charset=utf-8" });
+            conn.send(stanza);
+            equal(setRetRequestHeaderStub.getCalls()[1].args[0], "Content-Type");
+            equal(setRetRequestHeaderStub.getCalls()[1].args[1], "text/plain; charset=utf-8");
+            sendStub.restore();
+            timeoutStub.restore();
+            setRetRequestHeaderStub.restore();
+        });
+
         test("Cookies can be added to the document passing them as options to Strophe.Connection", function () {
             var stanza = $pres();
             var conn = new Strophe.Connection(


### PR DESCRIPTION
When doing some load testing we noticed that we were seeing a lot of overhead from preflight requests (due to the `text/xml` content type header)

This pull request allows setting a custom content type in the connection options to avoid the preflight overhead.