### PR TITLE
get inactivity attribute from session creation response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Strophe.js Change Log
 
+## Version 1.2.10 - Unreleased
+* #216 Get inactivity attribute from session creation response
+
 ## Version 1.2.9 - 2016-10-24
 * Allow SASL mechanisms to be supported to be passed in as option to `Strophe.Connection` constructor.
 * Add new matching option to `Strophe.Handler`, namely `ignoreNamespaceFragment`.

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -161,6 +161,7 @@ Strophe.Bosh = function(connection) {
     this.wait = 60;
     this.window = 5;
     this.errors = 0;
+    this.inactivity = null;
 
     this._requests = [];
 };
@@ -390,6 +391,8 @@ Strophe.Bosh.prototype = {
         if (hold) { this.hold = parseInt(hold, 10); }
         var wait = bodyWrap.getAttribute('wait');
         if (wait) { this.wait = parseInt(wait, 10); }
+        var inactivity = bodyWrap.getAttribute('inactivity');
+        if (inactivity) { this.inactivity = parseInt(inactivity, 10); }
     },
 
     /** PrivateFunction: _disconnect


### PR DESCRIPTION
fix #216

Currently this is untested, I will do it tomorrow.