### PR TITLE
Add the error text to the message instead of duplicating the condition

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -139,7 +139,7 @@ Strophe.Websocket.prototype = {
         }
 
         if (text) {
-            errorString += " - " + condition;
+            errorString += " - " + text;
         }
 
         Strophe.error(errorString);


### PR DESCRIPTION
It looks like the error condition was being duplicated in the error message instead of the error text. This fix can be helpful when debugging connection issues. 