### PR TITLE
SASL OAUTHBEARER should not require a JID node.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1782,8 +1782,9 @@ Strophe.Connection.prototype = {
      *
      *  Parameters:
      *    (String) jid - The user's JID.  This may be a bare JID,
-     *      or a full JID.  If a node is not supplied, SASL ANONYMOUS
-     *      authentication will be attempted.
+     *      or a full JID.  If a node is not supplied, SASL OAUTHBEARER or
+     *      SASL ANONYMOUS authentication will be attempted (OAUTHBEARER will
+     *      process the provided password value as an access token).
      *    (String) pass - The user's password.
      *    (Function) callback - The connect callback function.
      *    (Integer) wait - The optional HTTPBIND wait value.  This is the
@@ -3583,18 +3584,21 @@ Strophe.SASLOAuthBearer = function() {};
 Strophe.SASLOAuthBearer.prototype = new Strophe.SASLMechanism("OAUTHBEARER", true, 60);
 
 Strophe.SASLOAuthBearer.prototype.test = function(connection) {
-    return connection.authcid !== null;
+    return connection.pass !== null;
 };
 
 Strophe.SASLOAuthBearer.prototype.onChallenge = function(connection) {
-    var auth_str = 'n,a=';
-    auth_str = auth_str + connection.authzid;
+    var auth_str = 'n,';
+    if (connection.authcid !== null) {
+      auth_str = auth_str + 'a=' + connection.authzid;
+    }
     auth_str = auth_str + ',';
     auth_str = auth_str + "\u0001";
     auth_str = auth_str + 'auth=Bearer ';
     auth_str = auth_str + connection.pass;
     auth_str = auth_str + "\u0001";
     auth_str = auth_str + "\u0001";
+
     return utils.utf16to8(auth_str);
 };
 


### PR DESCRIPTION
When performing authentication via the SASL OAUTHBEARER mechanism, the provided token
often contains the desired user identity. As the OAUTHBEARER mechanism specification
does not _require_ this, such an identity can, optionally, be provided as a value
distinct from the token.

In the old implementation of OAUTHBEARER in Strophe.js, the node-part of the JID provided
to the connect method was used for this optional user identity. Strophe.js regarded the
node-part as a required attribute for OAUTHBEARER, and would always use its value.

When the access token contains the desired user identity, it is undesirable to explicitly
have to define this identity 'out-of-band' of the token again. This would require the
client to be able to parse the token, or have knowledge of the desired identity in another
fashion.

Instead, it is desirable to be able to connect with only the access token, when this token
contains the desired user identity. When needed, a user identity can be provided via the
node-part of the JID, but this should be optional.