### PR TITLE
Set CONNFAIL error status when connection fails on Safari 10

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -342,9 +342,15 @@ Strophe.Websocket.prototype = {
      *
      * Nothing to do here for WebSockets
      */
-    _onClose: function() {
+    _onClose: function(e) {
         if(this._conn.connected && !this._conn.disconnecting) {
             Strophe.error("Websocket closed unexpectedly");
+            this._conn._doDisconnect();
+        } else if (e && e.code === 1006 && !this._conn.connected && this.socket) {
+            // in case the onError callback was not called (Safari 10 does not call onerror when the initial connection fails)
+            // we need to dispatch a CONNFAIL status update to be consistent with the behavior on other browsers
+            Strophe.error("Websocket closed unexcectedly");
+            this._conn._changeConnectStatus(Strophe.Status.CONNFAIL, "The WebSocket connection could not be established or was disconnected.");
             this._conn._doDisconnect();
         } else {
             Strophe.info("Websocket closed");


### PR DESCRIPTION
Safari does not raise `onerror` if the connection abnormally terminates. This correctly sets the connection as failed in this case, to bring Safari in line with how other browsers handle it.

Refs https://github.com/strophe/strophejs/issues/72