### PR TITLE
Make `_no_auth_received` a connection-level method

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -470,26 +470,6 @@ Strophe.Bosh.prototype = {
         }
     },
 
-    /** PrivateFunction: _no_auth_received
-     *
-     * Called on stream start/restart when no stream:features
-     * has been received and sends a blank poll request.
-     */
-    _no_auth_received: function (_callback) {
-        if (_callback) {
-            _callback = _callback.bind(this._conn);
-        } else {
-            _callback = this._conn._connect_cb.bind(this._conn);
-        }
-        var body = this._buildBody();
-        this._requests.push(
-                new Strophe.Request(body.tree(),
-                    this._onRequestStateChange.bind(
-                        this, _callback.bind(this._conn)),
-                    body.tree().getAttribute("rid")));
-        this._throttledRequestHandler();
-    },
-
     /** PrivateFunction: _onDisconnectTimeout
      *  _Private_ timeout handler for handling non-graceful disconnection.
      *

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -368,24 +368,6 @@ Strophe.Websocket.prototype = {
         }
     },
 
-    /** PrivateFunction: _no_auth_received
-     *
-     * Called on stream start/restart when no stream:features
-     * has been received.
-     */
-    _no_auth_received: function (_callback) {
-        Strophe.error("Server did not send any auth methods");
-        this._conn._changeConnectStatus(
-            Strophe.Status.CONNFAIL,
-            "Server did not send any auth methods"
-        );
-        if (_callback) {
-            _callback = _callback.bind(this._conn);
-            _callback();
-        }
-        this._conn._doDisconnect();
-    },
-
     /** PrivateFunction: _onDisconnectTimeout
      *  _Private_ timeout handler for handling non-graceful disconnection.
      *


### PR DESCRIPTION
Make `_no_auth_received` a connection-level method instead of a protocol-level one, since such a distinction doesn't appear necessary.

For BOSH connections, we no longer send a poll request, but instead disconnect like we already do with websocket connections.

I made this change so that chat clients ([converse.js](https://conversejs.org) in my case), can better communicate a connection failure resulting from a mismatch of SASL authentication mechanisms supported by the client and offered by the server.

Also made constants out of hard-coded error conditions.