### PR TITLE
remove "browser" engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "clean": "make clean",
     "doc": "make doc"
   },
-  "engines": {
-    "browser": "*"
-  },
   "volo": {
     "url": "https://raw.githubusercontent.com/strophe/strophejs/release-{version}/strophe.js"
   },


### PR DESCRIPTION
Yarn 0.27.05 flags "browser" as an invalid engine. I propose to remove it, unless there is a need for it which I am not aware of.