### PR TITLE
Fix for React-Native: parse responseText if responseXML is missing

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -97,6 +97,9 @@ Strophe.Request.prototype = {
             Strophe.debug("Got responseText but no responseXML; attempting to parse it with DOMParser...");
             try {
                 node = new DOMParser().parseFromString(this.xhr.responseText, 'application/xml').documentElement;
+                if (!node) {
+                    throw new Error('Parsing produced null node');
+                }
             } catch (e) {
                 Strophe.error("invalid response received: " + e);
                 Strophe.error("responseText: " + this.xhr.responseText);

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -93,9 +93,15 @@ Strophe.Request.prototype = {
                 throw "parsererror";
             }
         } else if (this.xhr.responseText) {
-            Strophe.error("invalid response received");
-            Strophe.error("responseText: " + this.xhr.responseText);
-            throw "badformat";
+            // In React Native, we may get responseText but no responseXML.  We can try to parse it manually.
+            Strophe.debug("Got responseText but no responseXML; attempting to parse it with DOMParser...");
+            try {
+                node = new DOMParser().parseFromString(this.xhr.responseText, 'application/xml').documentElement;
+            } catch (e) {
+                Strophe.error("invalid response received: " + e);
+                Strophe.error("responseText: " + this.xhr.responseText);
+                throw "badformat";
+            }
         }
 
         return node;


### PR DESCRIPTION
We are using create-react-native-app and Expo.

Responses which worked fine in the browser did not work in the iOS Simulator, running Expo, because `responseXML` was undefined.

Our solution was to simple parse `responseText` ourselves.