### PR TITLE
Log fatal errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.2.15 - (Unreleased)
 * #259 XML element should be sent to xmlOutput
 * #266 Support Browserify/CommonJS. `require('strophe.js/src/wrapper')`
+* #288 Strophe logs fatal errors by default.
 
 ## Version 1.2.14 - 2017-06-15
 * #231 SASL OAuth Bearer authentication should not require a JID node, when a user identifer

--- a/src/core.js
+++ b/src/core.js
@@ -819,7 +819,7 @@ Strophe = {
      *
      *  This function is called whenever the Strophe library calls any
      *  of the logging functions.  The default implementation of this
-     *  function does nothing.  If client code wishes to handle the logging
+     *  function logs only fatal errors.  If client code wishes to handle the logging
      *  messages, it should override this with
      *  > Strophe.log = function (level, msg) {
      *  >   (user code here)
@@ -843,11 +843,13 @@ Strophe = {
      *      be one of the values in Strophe.LogLevel.
      *    (String) msg - The log message.
      */
-    /* jshint ignore:start */
     log: function (level, msg) {
-        return;
+        if (level === this.LogLevel.FATAL &&
+            typeof window.console === 'object' &&
+            typeof window.console.error === 'function') {
+            window.console.error(msg);
+        }
     },
-    /* jshint ignore:end */
 
     /** Function: debug
      *  Log a message at the Strophe.LogLevel.DEBUG level.


### PR DESCRIPTION
As you know fatal errors may make the app stop working, so what will happen if the user did not override the log function?! Nothing, the app crashes and the user never knows what happened.

The same situation happened to me in a big project and took a couple of days to find what is broken.