### PR TITLE
Refine _connect_cb_wrapper, convert messages at top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Strophe.js Change Log
 
+## Version 1.2.16 - (Unreleased)
+* Fix websocket close handler exception and reporting
+
 ## Version 1.2.15 - (2018-05-21)
 * #259 XML element should be sent to xmlOutput
 * #266 Support Browserify/CommonJS. `require('strophe.js/src/wrapper')`

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -240,10 +240,10 @@ Strophe.Websocket.prototype = {
      */
     _connect_cb_wrapper: function(message) {
         // Strip the XML Declaration, if there is one
-        const data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
+        var data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
         if (data === '') return;
         // Parse the raw string to an XML element
-        const parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+        var parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
         // Report this input to the raw and xml handlers
         this._conn.xmlInput(parsedMessage);
         this._conn.rawInput(message.data);
@@ -255,7 +255,7 @@ Strophe.Websocket.prototype = {
                 this._connect_cb(parsedMessage);
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
-            const see_uri = parsedMessage.getAttribute("see-other-uri");
+            var see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
                 this._conn._changeConnectStatus(
                     Strophe.Status.REDIRECT,
@@ -272,8 +272,8 @@ Strophe.Websocket.prototype = {
                 this._conn._doDisconnect();
             }
         } else {
-            const streamWrappedData = this._streamWrap(message.data);
-            const elem = new DOMParser().parseFromString(streamWrappedData, "text/xml").documentElement;
+            var streamWrappedData = this._streamWrap(message.data);
+            var elem = new DOMParser().parseFromString(streamWrappedData, "text/xml").documentElement;
             this.socket.onmessage = this._onMessage.bind(this);
             this._conn._connect_cb(elem, null, message.data);
         }

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -255,13 +255,13 @@ Strophe.Websocket.prototype = {
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
             // Parse the raw string to an XML element
-            const parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+            var parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
             // Report this input to the raw and xml handlers
             this._conn.xmlInput(parsedMessage);
             this._conn.rawInput(message.data);
             var see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
-                var service = connection.service;
+                var service = this._conn.service;
                 // Valid scenarios: WSS->WSS, WS->ANY
                 var isSecureRedirect = (service.indexOf("wss:") >= 0 && see_uri.indexOf("wss:") >= 0) || (service.indexOf("ws:") >= 0);
                 if(isSecureRedirect) {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -254,9 +254,12 @@ Strophe.Websocket.prototype = {
                 this._connect_cb(streamStart);
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
+            // Parse the raw string to an XML element
+            const parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+            // Report this input to the raw and xml handlers
+            this._conn.xmlInput(parsedMessage);
             this._conn.rawInput(message.data);
-            this._conn.xmlInput(message);
-            var see_uri = message.getAttribute("see-other-uri");
+            var see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
                 this._conn._changeConnectStatus(
                     Strophe.Status.REDIRECT,

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -239,24 +239,23 @@ Strophe.Websocket.prototype = {
      * message handler. On receiving a stream error the connection is terminated.
      */
     _connect_cb_wrapper: function(message) {
+        // Strip the XML Declaration, if there is one
+        const data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
+        if (data === '') return;
+        // Parse the raw string to an XML element
+        const parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+        // Report this input to the raw and xml handlers
+        this._conn.xmlInput(parsedMessage);
+        this._conn.rawInput(message.data);
+        // Begin handling tags
         if (message.data.indexOf("<open ") === 0 || message.data.indexOf("<?xml") === 0) {
-            // Strip the XML Declaration, if there is one
-            var data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
-            if (data === '') return;
-
-            var streamStart = new DOMParser().parseFromString(data, "text/xml").documentElement;
-            this._conn.xmlInput(streamStart);
-            this._conn.rawInput(message.data);
-
             //_handleStreamSteart will check for XML errors and disconnect on error
-            if (this._handleStreamStart(streamStart)) {
+            if (this._handleStreamStart(parsedMessage)) {
                 //_connect_cb will check for stream:error and disconnect on error
-                this._connect_cb(streamStart);
+                this._connect_cb(parsedMessage);
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
-            this._conn.rawInput(message.data);
-            this._conn.xmlInput(message);
-            var see_uri = message.getAttribute("see-other-uri");
+            const see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
                 this._conn._changeConnectStatus(
                     Strophe.Status.REDIRECT,
@@ -273,8 +272,8 @@ Strophe.Websocket.prototype = {
                 this._conn._doDisconnect();
             }
         } else {
-            var string = this._streamWrap(message.data);
-            var elem = new DOMParser().parseFromString(string, "text/xml").documentElement;
+            const streamWrappedData = this._streamWrap(message.data);
+            const elem = new DOMParser().parseFromString(streamWrappedData, "text/xml").documentElement;
             this.socket.onmessage = this._onMessage.bind(this);
             this._conn._connect_cb(elem, null, message.data);
         }

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -261,13 +261,18 @@ Strophe.Websocket.prototype = {
             this._conn.rawInput(message.data);
             var see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
-                this._conn._changeConnectStatus(
-                    Strophe.Status.REDIRECT,
-                    "Received see-other-uri, resetting connection"
-                );
-                this._conn.reset();
-                this._conn.service = see_uri;
-                this._connect();
+                var service = connection.service;
+                // Valid scenarios: WSS->WSS, WS->ANY
+                var isSecureRedirect = (service.indexOf("wss:") >= 0 && see_uri.indexOf("wss:") >= 0) || (service.indexOf("ws:") >= 0);
+                if(isSecureRedirect) {
+                    this._conn._changeConnectStatus(
+                        Strophe.Status.REDIRECT,
+                        "Received see-other-uri, resetting connection"
+                    );
+                    this._conn.reset();
+                    this._conn.service = see_uri;
+                    this._connect();
+                }
             } else {
                 this._conn._changeConnectStatus(
                     Strophe.Status.CONNFAIL,

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -240,10 +240,10 @@ Strophe.Websocket.prototype = {
      */
     _connect_cb_wrapper: function(message) {
         // Strip the XML Declaration, if there is one
-        var data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
+        const data = message.data.replace(/^(<\?.*?\?>\s*)*/, "");
         if (data === '') return;
         // Parse the raw string to an XML element
-        var parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+        const parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
         // Report this input to the raw and xml handlers
         this._conn.xmlInput(parsedMessage);
         this._conn.rawInput(message.data);
@@ -255,7 +255,7 @@ Strophe.Websocket.prototype = {
                 this._connect_cb(parsedMessage);
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
-            var see_uri = parsedMessage.getAttribute("see-other-uri");
+            const see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
                 this._conn._changeConnectStatus(
                     Strophe.Status.REDIRECT,
@@ -272,8 +272,8 @@ Strophe.Websocket.prototype = {
                 this._conn._doDisconnect();
             }
         } else {
-            var streamWrappedData = this._streamWrap(message.data);
-            var elem = new DOMParser().parseFromString(streamWrappedData, "text/xml").documentElement;
+            const streamWrappedData = this._streamWrap(message.data);
+            const elem = new DOMParser().parseFromString(streamWrappedData, "text/xml").documentElement;
             this.socket.onmessage = this._onMessage.bind(this);
             this._conn._connect_cb(elem, null, message.data);
         }


### PR DESCRIPTION
Hi!

This PR does a couple things:

- Fixes an issue where `getAttribute is not a function` would be thrown whenever the `<close>` tag is received, since we were checking for the attribute `see-other-uri` before converting to an XML element using the `DomParser`. Originally I converted to XML inside the if block for `<close>`. But...
- Changes the behavior such that XML conversion happens at the beginning of the handler since all three blocks (should) do the parsing anyway. Additionally, we report the raw data and parsed XML element at the beginning as well.
- ~~Converts all `var` in this handler to `const`. I noticed that `var` is being used quite a lot, but particularly in a large `if-else` block like this one, declaring `var`s can be very tricky as the variables escape their block scope to the function scope. If requested I can revert back to vars.~~ Reverted back to `var` per your lint rules.