### PR TITLE
Fix typing error on SCRAM-SHA-1 client nonce generation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3349,7 +3349,7 @@ Strophe.SASLSHA1.prototype.test = function(connection) {
 };
 
 Strophe.SASLSHA1.prototype.onChallenge = function(connection, challenge, test_cnonce) {
-    const cnonce = test_cnonce || MD5.hexdigest(Math.random() * 1234567890);
+    const cnonce = test_cnonce || MD5.hexdigest("" + (Math.random() * 1234567890));
     let auth_str = "n=" + utils.utf16to8(connection.authcid);
     auth_str += ",r=";
     auth_str += cnonce;


### PR DESCRIPTION
Client nonce was always the same (d41d8cd98f00b204e9800998ecf8427e).

MD5.hexdigest(...) needs to take a string. With a number, it computes an
empty MD5.