### PR TITLE
[WIP] Node compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14415,6 +14415,12 @@
         "slide": "^1.1.5"
       }
     },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "optional": true
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4335,12 +4335,12 @@
       }
     },
     "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.x"
       }
     },
     "fragment-cache": {
@@ -6470,9 +6470,9 @@
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
     "loose-envify": {
@@ -6887,6 +6887,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -12210,6 +12216,15 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -12899,9 +12914,9 @@
       "dev": true
     },
     "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "schema-utils": {
@@ -12999,15 +13014,19 @@
       "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
       }
     },
     "sinon-qunit": {
@@ -13534,6 +13553,12 @@
         "rimraf": "~2.2.6"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13698,6 +13723,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1343,6 +1343,12 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "optional": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -5906,11 +5912,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "istextorbinary": {
       "version": "2.2.1",
@@ -14418,6 +14419,15 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
+      }
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "optional": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
       }
     },
     "xmldom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5902,6 +5902,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "istextorbinary": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14430,6 +14430,12 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+      "optional": true
+    },
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,6 +1135,11 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   },
   "dependencies": {
     "isomorphic-ws": "^4.0.1"
+  },
+  "optionalDependencies": {
+    "xmldom": "^0.1.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,10 +68,10 @@
     "yarpm": "^0.2.1"
   },
   "dependencies": {
-    "abab": "^2.0.0",
-    "isomorphic-ws": "^4.0.1"
+    "abab": "^2.0.0"
   },
   "optionalDependencies": {
+    "ws": "^6.2.1",
     "xmldom": "^0.1.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "yarpm": "^0.2.1"
   },
   "dependencies": {
+    "abab": "^2.0.0",
     "isomorphic-ws": "^4.0.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "webpack": "^4.0.1",
     "webpack-cli": "^2.1.4",
     "yarpm": "^0.2.1"
+  },
+  "dependencies": {
+    "isomorphic-ws": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "minimist": "^1.2.0",
     "npm": "^5.7.1",
     "qunitjs": "~1.16.0",
-    "requirejs": "2.3.5",
+    "requirejs": "^2.3.5",
     "run-headless-chromium": "^0.1.1",
     "sinon": "1.17.7",
     "sinon-qunit": "~2.0.0",
@@ -72,6 +72,7 @@
   },
   "optionalDependencies": {
     "ws": "^6.2.1",
+    "xhr2": "^0.1.4",
     "xmldom": "^0.1.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "qunitjs": "~1.16.0",
     "requirejs": "^2.3.5",
     "run-headless-chromium": "^0.1.1",
-    "sinon": "1.17.7",
+    "sinon": "^2.4.1",
     "sinon-qunit": "~2.0.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "message",
     "bosh",
     "websocket",
-    "browser"
+    "browser",
+    "node"
   ],
   "files": [
     "dist/",

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -11,6 +11,16 @@ import core from 'core';
 
 const Strophe = core.Strophe;
 const $build = core.$build;
+let nodeXHR;
+// If running in a non-browser environment, like nodejs, load
+// optional modules providing alternatives to browser globals
+if (typeof window === 'undefined') {
+    try {
+        nodeXHR = require('xhr2');
+    } catch (err) {
+        core.Strophe.error('You must install "xhr2" to use BOSH on nodejs');
+    }
+}
 
 
 /** PrivateClass: Strophe.Request
@@ -110,13 +120,15 @@ Strophe.Request.prototype = {
      */
     _newXHR: function () {
         let xhr = null;
-        if (window.XMLHttpRequest) {
+        if (typeof window === 'undefined') {
+            xhr = nodeXHR;
+        } else if (window.XMLHttpRequest) {
             xhr = new XMLHttpRequest();
-            if (xhr.overrideMimeType) {
-                xhr.overrideMimeType("text/xml; charset=utf-8");
-            }
         } else if (window.ActiveXObject) {
             xhr = new ActiveXObject("Microsoft.XMLHTTP");
+        }
+        if (xhr.overrideMimeType) {
+            xhr.overrideMimeType("text/xml; charset=utf-8");
         }
         // use Function.bind() to prepend ourselves as an argument
         xhr.onreadystatechange = this.func.bind(null, this);

--- a/src/core.js
+++ b/src/core.js
@@ -521,10 +521,13 @@ const Strophe = {
         if (DOMParser) {
             const parser = new DOMParser();
             node = parser.parseFromString(html, "text/xml");
-        } else {
+        } else if (ActiveXObject) {
             node = new ActiveXObject("Microsoft.XMLDOM");
             node.async="false";
             node.loadXML(html);
+        } else {
+            const parser = require('xmldom').DOMParser;
+            node = parser.parseFromString(html, "text/xml");
         }
         return node;
     },

--- a/src/core.js
+++ b/src/core.js
@@ -11,6 +11,15 @@ import MD5 from 'md5';
 import SHA1 from 'sha1';
 import utils from 'utils';
 
+let xmldom;
+if (typeof document === 'undefined') {
+    try {
+        xmldom = require('xmldom');
+    } catch (err) {
+        Strophe.error('xmldom is a required dependency on nodejs.');
+    }
+}
+
 /** Function: $build
  *  Create a Strophe.Builder.
  *  This is an alias for 'new Strophe.Builder(name, attrs)'.
@@ -338,7 +347,6 @@ const Strophe = {
     _makeGenerator: function () {
         let doc;
         if (typeof document === 'undefined') {
-            const xmldom = require('xmldom')
             doc = new xmldom.DOMImplementation().createDocument('jabber:client', 'strophe', null)
         } else if (
             document.implementation.createDocument === undefined ||
@@ -526,7 +534,7 @@ const Strophe = {
             node.async="false";
             node.loadXML(html);
         } else {
-            const parser = require('xmldom').DOMParser;
+            const parser = xmldom.DOMParser;
             node = parser.parseFromString(html, "text/xml");
         }
         return node;

--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,7 @@
 */
 /*global define, document, sessionStorage, setTimeout, clearTimeout, ActiveXObject, DOMParser, btoa, atob, module */
 
+import { atob, btoa } from 'abab';
 import MD5 from 'md5';
 import SHA1 from 'sha1';
 import utils from 'utils';

--- a/src/core.js
+++ b/src/core.js
@@ -336,11 +336,16 @@ const Strophe = {
      */
     _makeGenerator: function () {
         let doc;
-        // IE9 does implement createDocument(); however, using it will cause the browser to leak memory on page unload.
-        // Here, we test for presence of createDocument() plus IE's proprietary documentMode attribute, which would be
-        // less than 10 in the case of IE9 and below.
-        if (document.implementation.createDocument === undefined ||
-                    document.implementation.createDocument && document.documentMode && document.documentMode < 10) {
+        if (typeof document === 'undefined') {
+            const xmldom = require('xmldom')
+            doc = new xmldom.DOMImplementation().createDocument('jabber:client', 'strophe', null)
+        } else if (
+            document.implementation.createDocument === undefined ||
+            document.implementation.createDocument && document.documentMode && document.documentMode < 10
+        ) {
+            // IE9 does implement createDocument(); however, using it will cause the browser to leak memory on page unload.
+            // Here, we test for presence of createDocument() plus IE's proprietary documentMode attribute, which would be
+            // less than 10 in the case of IE9 and below.
             doc = this._getIEXmlDom();
             doc.appendChild(doc.createElement('strophe'));
         } else {
@@ -1159,7 +1164,7 @@ Strophe.Builder.prototype = {
      *    The Strophe.Builder object.
      */
     h: function (html) {
-        const fragment = document.createElement('body');
+        const fragment = Strophe.xmlGenerator().createElement('body');
         // force the browser to try and fix any invalid HTML tags
         fragment.innerHTML = html;
         // copy cleaned html into an xml dom

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -7,10 +7,10 @@
 
 /* global window, clearTimeout, WebSocket, DOMParser */
 
-import WebSocket from 'isomorphic-ws';
 import core from 'core';
 
-const DOMParser = typeof DOMParser === 'undefined' ? require('xmldom').DOMParser : DOMParser
+const WebSocket = typeof WebSocket === 'undefined' ? require('ws') : WebSocket;
+const DOMParser = typeof DOMParser === 'undefined' ? require('xmldom').DOMParser : DOMParser;
 const Strophe = core.Strophe;
 const $build = core.$build;
 
@@ -157,7 +157,7 @@ Strophe.Websocket.prototype = {
         // Ensure that there is no open WebSocket from a previous Connection.
         this._closeSocket();
 
-        // Create the new WobSocket
+        // Create the new WebSocket
         this.socket = new WebSocket(this._conn.service, "xmpp");
         this.socket.onopen = this._onOpen.bind(this);
         this.socket.onerror = this._onError.bind(this);

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -9,8 +9,22 @@
 
 import core from 'core';
 
-const WebSocket = typeof WebSocket === 'undefined' ? require('ws') : WebSocket;
-const DOMParser = typeof DOMParser === 'undefined' ? require('xmldom').DOMParser : DOMParser;
+let nodeDOMParser;
+let nodeWebSocket;
+// If running in a non-browser environment, like nodejs, load
+// optional modules providing alternatives to browser globals
+if (typeof WebSocket === 'undefined') {
+    try {
+        nodeWebSocket = require('ws');
+        nodeDOMParser = require('xmldom').DOMParser;
+    } catch (err) {
+        core.Strophe.error('You must install "ws" to use Websockets on nodejs');
+        core.Strophe.error('You must install "xmldom" to use Websockets on nodejs');
+    }
+}
+
+const DOMParser = typeof DOMParser === 'undefined' ? nodeDOMParser: DOMParser;
+const WebSocket = typeof WebSocket === 'undefined' ? nodeWebSocket : WebSocket;
 const Strophe = core.Strophe;
 const $build = core.$build;
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -10,6 +10,7 @@
 import WebSocket from 'isomorphic-ws';
 import core from 'core';
 
+const DOMParser = typeof DOMParser === 'undefined' ? require('xmldom').DOMParser : DOMParser
 const Strophe = core.Strophe;
 const $build = core.$build;
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -7,6 +7,7 @@
 
 /* global window, clearTimeout, WebSocket, DOMParser */
 
+import WebSocket from 'isomorphic-ws';
 import core from 'core';
 
 const Strophe = core.Strophe;

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,24 +1,23 @@
 <!DOCTYPE html>
 <html>
   <head>
-	<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+    <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
     <script>QUnit.config.autostart = false;</script>
-    <script src="../main.js"></script>
-	<script src="../node_modules/requirejs/require.js" data-main="main.js"></script>
+    <script src="../node_modules/requirejs/require.js" data-main="main.js"></script>
     <link rel="stylesheet"
-	      href="../node_modules/qunitjs/qunit/qunit.css"
+	        href="../node_modules/qunitjs/qunit/qunit.css"
           type="text/css">
-    
+
     <title>Strophe.js Tests</title>
   </head>
   <body>
     <h1 id="qunit-header">Strophe.js Tests</h1>
     <h2 id="qunit-banner"></h2>
     <h2 id="qunit-userAgent"></h2>
-	<div id="qunit"></div>
-	<div id="qunit-fixture"></div>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
     <ol id="qunit-tests"></ol>
     <div id="main"></div>
-	<div id="qunit-testresult"></div>
+    <div id="qunit-testresult"></div>
   </body>
 </html>

--- a/tests/main.js
+++ b/tests/main.js
@@ -7,8 +7,8 @@ require.config({
         "basic":            "examples/basic",
 
         // Not really used, only to make requirejs not complain in tests
-        "xmldom":           "node_modules/xmldom/dom-parser",
-        "ws":               "node_modules/ws/index",
+        "ws":               "node_modules/ws/browser",
+        "xhr2":             "node_modules/xhr2/lib/browser",
 
         // Tests
         "jquery":           "node_modules/jquery/dist/jquery",
@@ -16,7 +16,15 @@ require.config({
         "sinon-qunit":      "node_modules/sinon-qunit/lib/sinon-qunit",
         "tests":            "tests/tests"
     },
-
+    map: {
+        // xmldom doesn't correctly load under AMD / requirejs
+        // map it to load 'ws' instead just to avoid the require error.
+        // It doesn't matter that it's a different module, as both of them
+        // are not actually used in the browser.
+        '*': {
+            'xmldom': 'ws'
+        }
+    },
     shim: {
         'sinon-qunit':  { deps: ['sinon']}
     }

--- a/tests/main.js
+++ b/tests/main.js
@@ -6,6 +6,10 @@ require.config({
         // Examples
         "basic":            "examples/basic",
 
+        // Not really used, only to make requirejs not complain in tests
+        "xmldom":           "node_modules/xmldom/dom-parser",
+        "ws":               "node_modules/ws/index",
+
         // Tests
         "jquery":           "node_modules/jquery/dist/jquery",
         "sinon":            "node_modules/sinon/pkg/sinon",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ const webpack = require('webpack');
 const config = {
     entry: path.resolve(__dirname, 'src/strophe.js'),
     externals: [{
-        "window": "window"
+        "window": "window",
+        "ws": "ws"
     }],
     output: {
         path: path.resolve(__dirname, 'dist'),
@@ -39,6 +40,10 @@ const config = {
     },
     resolve: {
         extensions: ['.js'],
+        // TODO: this only takes isomorphic-ws node entrypoint
+        // and not the browser one. Find a way to make webpack
+        // bundle both.
+        mainFields: ['main'],
         modules: [
             'node_modules',
             path.resolve(__dirname, "src")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ const config = {
         filename: 'strophe.js',
         library: 'strophe',
         libraryExport: 'default',
-        libraryTarget: 'umd'
+        libraryTarget: 'umd',
+        globalObject: "(typeof self !== 'undefined' ? self : this)"
     },
     devtool: 'source-map',
     module: {
@@ -27,7 +28,8 @@ const config = {
                     presets: [
                         ["@babel/preset-env", {
                             "targets": {
-                                "browsers": [">1%"]
+                                node: "8",
+                                browsers: ">1%"
                             }
                         }]
                     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ const config = {
     externals: [{
         "xmldom": "xmldom",
         "window": "window",
-        "ws": "ws"
+        "ws": "ws",
+        "xhr2": "xhr2"
     }],
     output: {
         path: path.resolve(__dirname, 'dist'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const webpack = require('webpack');
 const config = {
     entry: path.resolve(__dirname, 'src/strophe.js'),
     externals: [{
+        "xmldom": "xmldom",
         "window": "window",
         "ws": "ws"
     }],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,10 +41,6 @@ const config = {
     },
     resolve: {
         extensions: ['.js'],
-        // TODO: this only takes isomorphic-ws node entrypoint
-        // and not the browser one. Find a way to make webpack
-        // bundle both.
-        mainFields: ['main'],
         modules: [
             'node_modules',
             path.resolve(__dirname, "src")


### PR DESCRIPTION
This is a pull request to make strophe.js able to run in nodejs.

This pull request is still work in progress and not ready for merge, I've opened it so that we can start a discussion on this and others may be able to pitch in.

## Why

Strophejs is a very well written library, has an API nicer than most other xmpp node libraries, has [excellent external type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/strophe.js), has a nice plugin system, and the browser-specific stuff is already limited; therefore I think it's would be great to add node compatibility to be able to use strophe.js on the backend, for example to write xmpp bots.

## What's done

* Fix [webpack bug](https://github.com/webpack/webpack/issues/6525) that produced broken universal builds that required `window`
* Use `isomorphic-ws` to provide an universal websocket module that uses the native WebSocket object on browser and the [ws](https://www.npmjs.com/package/ws) package on node.
At the moment I have a problem with webpack only bundling the `node.js` or `browser.js` entrypoints of `isomorphic-ws`, and not both, so I think websockets under browsers are broken until I fix that 
* Use `xmldom` to provide `DOMParser`, `document` and the other DOM API used by `Strophe.Builder` to build xml stanzas.
* Use `abab` to provide a cross-platform standard-adhering implementation of `atob` and `btoa` used by `Strophe.Websocket`

Regarding the additional dependencies I've introduced:

* `abab` and `isomorphic-ws` are very small packages without dependencies, so I've added them directly.
* `ws` and `xmldom` are larger packages, but they are defined as peerDependency and optionalDependency, so they won't be installed automatically but it's the responisibility of users to installthose packages when using strophe.js under node.

This way the strophe.js bundle size remains pretty much the same. 

At this point, I already got strophe working using websockets in node.

## What's missing

### BOSH

At the moment I've not worked on BOSH yet. I was thinking as a first version, strophe.js could be compatibile with node only when using the websocket protocol, and later also add BOSH compatibility.

What's needed for BOSH:
* XmlHTTPRequest
* cookies

### Tests