### PR TITLE
Allow for explicit resource binding

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -506,9 +506,7 @@ Strophe.Bosh.prototype = {
             const req = this._requests.pop();
             req.abort = true;
             req.xhr.abort();
-            // jslint complains, but this is fine. setting to empty func
-            // is necessary for IE6
-            req.xhr.onreadystatechange = function () {}; // jshint ignore:line
+            req.xhr.onreadystatechange = function () {};
         }
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -1915,11 +1915,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (XMLElement) elem - The XML data received by the connection.
      */
-    /* jshint unused:false */
     xmlInput: function (elem) {
         return;
     },
-    /* jshint unused:true */
 
     /** Function: xmlOutput
      *  User overrideable function that receives XML data sent to the
@@ -1939,11 +1937,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (XMLElement) elem - The XMLdata sent by the connection.
      */
-    /* jshint unused:false */
     xmlOutput: function (elem) {
         return;
     },
-    /* jshint unused:true */
 
     /** Function: rawInput
      *  User overrideable function that receives raw data coming into the
@@ -1957,11 +1953,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (String) data - The data received by the connection.
      */
-    /* jshint unused:false */
     rawInput: function (data) {
         return;
     },
-    /* jshint unused:true */
 
     /** Function: rawOutput
      *  User overrideable function that receives raw data sent to the
@@ -1975,11 +1969,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (String) data - The data sent by the connection.
      */
-    /* jshint unused:false */
     rawOutput: function (data) {
         return;
     },
-    /* jshint unused:true */
 
     /** Function: nextValidRid
      *  User overrideable function that receives the new valid rid.
@@ -1992,11 +1984,9 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (Number) rid - The next valid rid
      */
-    /* jshint unused:false */
     nextValidRid: function (rid) {
         return;
     },
-    /* jshint unused:true */
 
     /** Function: send
      *  Send a stanza.
@@ -2775,7 +2765,6 @@ Strophe.Connection.prototype = {
     /** PrivateFunction: _attemptLegacyAuth
      *
      *  Attempt legacy (i.e. non-SASL) authentication.
-     *
      */
     _attemptLegacyAuth: function () {
         if (Strophe.getNodeFromJid(this.jid) === null) {
@@ -2837,7 +2826,6 @@ Strophe.Connection.prototype = {
         this.send(iq.tree());
         return false;
     },
-    /* jshint unused:true */
 
     /** PrivateFunction: _sasl_success_cb
      *  _Private_ handler for succesful SASL authentication.
@@ -3074,7 +3062,6 @@ Strophe.Connection.prototype = {
      *  Returns:
      *    false to remove the handler.
      */
-    /* jshint unused:false */
     _sasl_failure_cb: function (elem) {
         // delete unneeded handlers
         if (this._sasl_success_handler) {
@@ -3091,7 +3078,6 @@ Strophe.Connection.prototype = {
         this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
         return false;
     },
-    /* jshint unused:true */
 
     /** PrivateFunction: _auth2_cb
      *  _Private_ handler to finish legacy authentication.
@@ -3303,11 +3289,9 @@ Strophe.SASLMechanism.prototype = {
      *  Returns:
      *    (Boolean) If mechanism was able to run.
      */
-    /* jshint unused:false */
     test: function(connection) {
         return true;
     },
-    /* jshint unused:true */
 
     /** PrivateFunction: onStart
      *  Called before starting mechanism on some connection.
@@ -3330,11 +3314,9 @@ Strophe.SASLMechanism.prototype = {
      *  Returns:
      *    (String) Mechanism response.
      */
-    /* jshint unused:false */
     onChallenge: function (connection, challenge) {
         throw new Error("You should implement challenge handling!");
     },
-    /* jshint unused:true */
 
     /** PrivateFunction: onFailure
      *  Protocol informs mechanism implementation about SASL failure.

--- a/src/sha1.js
+++ b/src/sha1.js
@@ -6,8 +6,6 @@
  * Distributed under the BSD License
  * See http://pajhome.org.uk/crypt/md5 for details.
  */
-
-/* jshint undef: true, unused: true:, noarg: true, latedef: false */
 /* global define */
 
 /* Some functions and variables have been stripped for use with Strophe */


### PR DESCRIPTION
Currently Strophe automatically binds the user's resource as soon as the ` <bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/>` feature is advertised by the XMPP server.

In some cases it's however necessary to first do some other things before binding the resource. For example with XEP-0198 Stream Management, when you want to resume a session, you *have* to do this after the relevant feature has been advertised and *before* resource binding.

It's therefore necessary to be able to prevent Strophe from automatically doing resource binding, so that the client can first do some other tasks and then manually bind the resource.

I've therefore created a new option `explicitResourceBinding` which you can pass to Strophe.Connection to disable automatic binding. When this is set to `true`, the client has to call `.bind` manually at the appropriate time.

I've also improved the names of some callbacks to make it more clear what they're about and I've removed the jshint hints, since we no longer use jshint in Strophe.

CC @sualko, @LeartS (feedback welcome)

 