### PR TITLE
Reconnect with BOSH not receive SessionResultIQ

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2930,11 +2930,11 @@ Strophe.Connection.prototype = {
         if (bind.length > 0) {
             const jidNode = bind[0].getElementsByTagName("jid");
             if (jidNode.length > 0) {
+                this.authenticated = true;
                 this.jid = Strophe.getText(jidNode[0]);
                 if (this.do_session) {
                     this._establishSession();
                 } else {
-                    this.authenticated = true;
                     this._changeConnectStatus(Strophe.Status.CONNECTED, null);
                 }
             }
@@ -2991,6 +2991,7 @@ Strophe.Connection.prototype = {
             this.authenticated = true;
             this._changeConnectStatus(Strophe.Status.CONNECTED, null);
         } else if (elem.getAttribute("type") === "error") {
+            this.authenticated = false;
             Strophe.warn("Session creation failed.");
             this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
             return false;


### PR DESCRIPTION
When a user has presence/message on queue after reconnect, the SessionResultIQ could not be the direct response to iq. The response could be received in next messages.

This issue occurs with ejabberd 19.05

This impact BOSH due to the fact BOSH stop pulling if authenticated = false.
https://github.com/strophe/strophejs/blob/fbbac903fbf877d04a1324487ec0bc8e18f132ca/src/bosh.js#L522

Proposition : consider as authenticated until receiving SessionResultIQ.

Example of XMPP messages exchanged :
```xml
RECV :<body xmlns='http://jabber.org/protocol/httpbind' xmlns:xmpp='urn:xmpp:xbosh' xmlns:stream='http://etherx.jabber.org/streams' xmpp:version='1.0' authid='9473495389247984438' sid='6a5414ee1b255bc8c66c0815257db31c0eae535d' wait='20' ver='1.11' polling='2' inactivity='360' hold='1' xmpp:restartlogic='true' requests='2' secure='true' maxpause='120' from='chat.sample.docker'><stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>ANONYMOUS</mechanism><mechanism>PLAIN</mechanism></mechanisms><register xmlns='http://jabber.org/features/iq-register'/></stream:features></body>
SENT :<body rid='1151162895' xmlns='http://jabber.org/protocol/httpbind' sid='6a5414ee1b255bc8c66c0815257db31c0eae535d'><auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='PLAIN'>XXXXXXXXXXXXXXXX</auth></body>
RECV :<body xmlns='http://jabber.org/protocol/httpbind'><success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/></body>
SENT :<body rid='1151162896' xmlns='http://jabber.org/protocol/httpbind' sid='6a5414ee1b255bc8c66c0815257db31c0eae535d' to='chat.sample.docker' xml:lang='en' xmpp:restart='true' xmlns:xmpp='urn:xmpp:xbosh'/>
RECV :<body xmlns='http://jabber.org/protocol/httpbind' xmlns:stream='http://etherx.jabber.org/streams' xmlns:xmpp='urn:xmpp:xbosh' xmpp:version='1.0' authid='15234436987421695944'><stream:features><bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/><session xmlns='urn:ietf:params:xml:ns:xmpp-session'><optional/></session><c xmlns='http://jabber.org/protocol/caps' ver='ItSDEFEGRevSrpz0Fr5MsCy4ihQ=' node='http://www.process-one.net/en/ejabberd/' hash='sha-1'/><csi xmlns='urn:xmpp:csi:0'/></stream:features></body>
SENT :<body rid='1151162897' xmlns='http://jabber.org/protocol/httpbind' sid='6a5414ee1b255bc8c66c0815257db31c0eae535d'><iq type='set' id='_bind_auth_2' xmlns='jabber:client'><bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'><resource>livechat(15)</resource></bind></iq></body>
RECV :<body xmlns='http://jabber.org/protocol/httpbind'><iq xmlns='jabber:client' type='result' id='_bind_auth_2'><bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'><jid>r15_a9b97b32c7@chat.sample.docker/livechat(15)</jid></bind></iq></body>
SENT :<body rid='1151162898' xmlns='http://jabber.org/protocol/httpbind' sid='6a5414ee1b255bc8c66c0815257db31c0eae535d'><iq type='set' id='_session_auth_2' xmlns='jabber:client'><session xmlns='urn:ietf:params:xml:ns:xmpp-session'/></iq></body>
RECV :<body xmlns='http://jabber.org/protocol/httpbind'><presence xmlns='jabber:client' to='r15_a9b97b32c7@chat.sample.docker/livechat(15)' from='1_en@conference.chat.sample.docker' type='unavailable' id='15381016658623108265'/><presence xmlns='jabber:client' to='r15_a9b97b32c7@chat.sample.docker/livechat(15)' from='1_en@conference.chat.sample.docker/r15_a9b97b32c7' type='unavailable'><x xmlns='http://jabber.org/protocol/muc#user'><item jid='r15_a9b97b32c7@chat.sample.docker/livechat(15)' role='none' affiliation='none'/><status code='110'/></x></presence></body>
---
BUG: stop communication
---
SENT : Fix send empty for pulling and after receive
RECV :<body xmlns='http://jabber.org/protocol/httpbind'><iq xmlns='jabber:client' xml:lang='en' to='r15_a9b97b32c7@chat.sample.docker/livechat(15)' from='r15_a9b97b32c7@chat.sample.docker' type='result' id='_session_auth_2'/></body>
---
```