### PR TITLE
Fix node.querySelector is not a function

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -90,7 +90,7 @@ Strophe.Request.prototype = {
             node = new DOMParser().parseFromString(this.xhr.responseText, 'application/xml').documentElement;
             if (!node) {
                 throw new Error('Parsing produced null node');
-            } else if (node.querySelector('parsererror')) {
+            } else if (node.querySelector && node.querySelector('parsererror')) {
                 Strophe.error("invalid response received: " + node.querySelector('parsererror').textContent);
                 Strophe.error("responseText: " + this.xhr.responseText);
                 const error = new Error();


### PR DESCRIPTION
In React Native, `querySelector` is not supported with `xmldom` and it will throw an error.  We should check that this function exists before trying to call it.

Uncaught TypeError: node.querySelector is not a function
    at Strophe$1.Request.getResponse (9bd2a0ca-228f-4518-a…086378aa2a38:332193)
    at Strophe$1.Bosh._reqToData (9bd2a0ca-228f-4518-a…086378aa2a38:332709)
    at Strophe.Connection._connect_cb (9bd2a0ca-228f-4518-a…086378aa2a38:331471)
    at Strophe$1.Bosh._onRequestStateChange (9bd2a0ca-228f-4518-a…086378aa2a38:332561)

