### PR TITLE
Create a new websocket protocol, that works via a shared worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Strophe.js Change Log
 
+## Version 1.4.0 - (Unreleased)
+
+* #354: Strophe.js sends an authzid during PLAIN when not acting on behalf of another entity
+* Add support for running a websocket connection inside a shared worker
+
 ## Version 1.3.6 - (2020-06-15)
 
 - #250 Bugfix: OAuth's SASL priority being higher causes problems

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ watchjs: node_modules
 .PHONY: dist
 dist: $(STROPHE)
 
-$(STROPHE): src rollup.config.js node_modules Makefile node_modules
+$(STROPHE): src rollup.config.js node_modules Makefile
 	npm run build
 
 .PHONY: eslint

--- a/src/shared-connection-worker.js
+++ b/src/shared-connection-worker.js
@@ -1,0 +1,114 @@
+let manager;
+
+
+const Status = {
+    ERROR: 0,
+    CONNECTING: 1,
+    CONNFAIL: 2,
+    AUTHENTICATING: 3,
+    AUTHFAIL: 4,
+    CONNECTED: 5,
+    DISCONNECTED: 6,
+    DISCONNECTING: 7,
+    ATTACHED: 8,
+    REDIRECT: 9,
+    CONNTIMEOUT: 10,
+    BINDREQUIRED: 11,
+    ATTACHFAIL: 12
+}
+
+
+/** Class: ConnectionManager
+ *
+ * Manages the shared websocket connection as well as the ports of the
+ * connected tabs.
+ */
+class ConnectionManager {
+
+    constructor () {
+        this.ports = [];
+    }
+
+    addPort (port) {
+        this.ports.push(port);
+        port.addEventListener('message', e => {
+            const method = e.data[0];
+            try {
+                this[method](e.data.splice(1))
+            } catch (e) {
+                console?.error(e);
+            }
+        });
+        port.start();
+    }
+
+    _connect (data) {
+        this.jid = data[1];
+        this._closeSocket();
+        this.socket = new WebSocket(data[0], "xmpp");
+        this.socket.onopen = () => this._onOpen();
+        this.socket.onerror = (e) => this._onError(e);
+        this.socket.onclose = (e) => this._onClose(e);
+        this.socket.onmessage = (message) => this._onMessage(message);
+    }
+
+    _attach () {
+        if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
+            this.ports.forEach(p => p.postMessage(['_attachCallback', Status.ATTACHED, this.jid]));
+        } else {
+            this.ports.forEach(p => p.postMessage(['_attachCallback', Status.ATTACHFAIL]));
+        }
+    }
+
+    send (str) {
+        this.socket.send(str);
+    }
+
+    close (str) {
+        if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
+            try {
+                this.socket.send(str);
+            } catch (e) {
+                this.ports.forEach(p => p.postMessage(['log', 'error', e]));
+                this.ports.forEach(p => p.postMessage(
+                    ['log', 'error', "Couldn't send <close /> tag."]));
+            }
+        }
+    }
+
+    _onOpen () {
+        this.ports.forEach(p => p.postMessage(['_onOpen']));
+    }
+
+    _onClose (e) {
+        this.ports.forEach(p => p.postMessage(['_onClose', e.reason]));
+    }
+
+    _onMessage (message) {
+        const o = { 'data': message.data }
+        this.ports.forEach(p => p.postMessage(['_onMessage', o]));
+    }
+
+    _onError (error) {
+        this.ports.forEach(p => p.postMessage(['_onError', error.reason]));
+    }
+
+    _closeSocket () {
+        if (this.socket) {
+            try {
+                this.socket.onclose = null;
+                this.socket.onerror = null;
+                this.socket.onmessage = null;
+                this.socket.close();
+            } catch (e) {
+                this.ports.forEach(p => p.postMessage(['log', 'error', e]));
+            }
+        }
+        this.socket = null;
+    }
+}
+
+onconnect = function (e) {  // eslint-disable-line no-undef
+    manager = manager || new ConnectionManager();
+    manager.addPort(e.ports[0]);
+}

--- a/src/strophe.js
+++ b/src/strophe.js
@@ -2,6 +2,7 @@
 
 import './bosh';
 import './websocket';
+import './worker-websocket';
 import * as strophe from './core';
 
 global.$build = strophe.default.$build;

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,8 +54,7 @@ const utils = {
                     domain = cookieObj.domain ? ";domain="+cookieObj.domain : '';
                     path = cookieObj.path ? ";path="+cookieObj.path : '';
                 }
-                document.cookie =
-                    cookieName+'='+cookieValue + expires + domain + path;
+                document.cookie = cookieName+'='+cookieValue + expires + domain + path;
             }
         }
     }

--- a/src/worker-websocket.js
+++ b/src/worker-websocket.js
@@ -1,0 +1,149 @@
+/*
+    This program is distributed under the terms of the MIT license.
+    Please see the LICENSE file for details.
+
+    Copyright 2020, JC Brand
+*/
+
+import './websocket.js';
+import { $build, Strophe } from './core.js';
+
+const lmap = {};
+lmap['debug'] = Strophe.LogLevel.DEBUG;
+lmap['info'] = Strophe.LogLevel.INFO;
+lmap['warn'] = Strophe.LogLevel.WARN;
+lmap['error'] = Strophe.LogLevel.ERROR;
+lmap['fatal'] = Strophe.LogLevel.FATAL;
+
+
+/** Class: Strophe.WorkerWebsocket
+ *  _Private_ helper class that handles a websocket connection inside a shared worker.
+ */
+Strophe.WorkerWebsocket = class WorkerWebsocket extends Strophe.Websocket {
+
+    /** PrivateConstructor: Strophe.WorkerWebsocket
+     *  Create and initialize a Strophe.WorkerWebsocket object.
+     *
+     *  Parameters:
+     *    (Strophe.Connection) connection - The Strophe.Connection
+     *
+     *  Returns:
+     *    A new Strophe.WorkerWebsocket object.
+     */
+    constructor (connection) {
+        super(connection);
+        this._conn = connection;
+        this.worker = new SharedWorker(this._conn.options.worker, 'Strophe XMPP Connection');
+        this.worker.onerror = (e) => {
+            console?.error(e);
+            Strophe.log(Strophe.LogLevel.ERROR, `Shared Worker Error: ${e}`);
+        }
+    }
+
+    get socket () {
+        return {
+            'send': str => this.worker.port.postMessage(['send', str])
+        }
+    }
+
+    _connect () {
+        this._messageHandler = (m) => this._onInitialMessage(m);
+        this.worker.port.start();
+        this.worker.port.onmessage = (ev) => this._onWorkerMessage(ev);
+        this.worker.port.postMessage(['_connect', this._conn.service, this._conn.jid]);
+    }
+
+    _attach (callback) {
+        this._messageHandler = (m) => this._onMessage(m);
+        this._conn.connect_callback = callback;
+        this.worker.port.start();
+        this.worker.port.onmessage = (ev) => this._onWorkerMessage(ev);
+        this.worker.port.postMessage(['_attach', this._conn.service]);
+    }
+
+    _attachCallback (status, jid) {
+        if (status === Strophe.Status.ATTACHED) {
+            this._conn.jid = jid;
+            this._conn.authenticated = true;
+            this._conn.connected = true;
+            this._conn.restored = true;
+            this._conn._changeConnectStatus(Strophe.Status.ATTACHED);
+        } else if (status === Strophe.Status.ATTACHFAIL) {
+            this._conn.authenticated = false;
+            this._conn.connected = false;
+            this._conn.restored = false;
+            this._conn._changeConnectStatus(Strophe.Status.ATTACHFAIL);
+        }
+    }
+
+    _disconnect (readyState, pres) {
+        pres && this._conn.send(pres);
+        const close = $build("close", { "xmlns": Strophe.NS.FRAMING });
+        this._conn.xmlOutput(close.tree());
+        const closeString = Strophe.serialize(close);
+        this._conn.rawOutput(closeString);
+        this.worker.port.postMessage(['send', closeString]);
+        this._conn._doDisconnect();
+    }
+
+    _onClose (e) {
+        if (this._conn.connected && !this._conn.disconnecting) {
+            Strophe.error("Websocket closed unexpectedly");
+            this._conn._doDisconnect();
+        } else if (e && e.code === 1006 && !this._conn.connected) {
+            // in case the onError callback was not called (Safari 10 does not
+            // call onerror when the initial connection fails) we need to
+            // dispatch a CONNFAIL status update to be consistent with the
+            // behavior on other browsers.
+            Strophe.error("Websocket closed unexcectedly");
+            this._conn._changeConnectStatus(
+                Strophe.Status.CONNFAIL,
+                "The WebSocket connection could not be established or was disconnected."
+            );
+            this._conn._doDisconnect();
+        } else {
+            Strophe.debug("Websocket closed");
+        }
+    }
+
+    _closeSocket () {
+        this.worker.port.postMessage(['_closeSocket']);
+    }
+
+    /** PrivateFunction: _replaceMessageHandler
+     *
+     * Called by _onInitialMessage in order to replace itself with the general message handler.
+     * This method is overridden by Strophe.WorkerWebsocket, which manages a
+     * websocket connection via a service worker and doesn't have direct access
+     * to the socket.
+     */
+    _replaceMessageHandler () {
+        this._messageHandler = (m) => this._onMessage(m);
+    }
+
+    /** PrivateFunction: _onWorkerMessage
+     * _Private_ function that handles messages received from the service worker
+     */
+    _onWorkerMessage (ev) {
+        const { data } = ev;
+        const method_name = data[0];
+        if (method_name === '_onMessage') {
+            this._messageHandler(data[1]);
+        } else if (method_name in this) {
+            try {
+                this[method_name].apply(this, ev.data.slice(1));
+            } catch (e) {
+                Strophe.log(Strophe.LogLevel.ERROR, e);
+            }
+        } else if (method_name === 'log') {
+            const level = data[1];
+            const msg = data[2]
+            Strophe.log(lmap[level], msg);
+        } else {
+            Strophe.log(
+                Strophe.LogLevel.ERROR,
+                `Found unhandled service worker message: ${data}`
+            );
+        }
+    }
+}


### PR DESCRIPTION
Inside the worker we manage a WebSocket connection.
We add a class that extends `Strophe.WebSocket` and which acts as a protocol wrapper set to the `__proto` attribute of the Strophe.Connection.
