### PR TITLE
export b64_sha1 for strophejs-plugin-caps compatibility

### DIFF
--- a/src/strophe.js
+++ b/src/strophe.js
@@ -10,6 +10,7 @@ global.$iq = strophe.default.$iq;
 global.$msg = strophe.default.$msg;
 global.$pres = strophe.default.$pres;
 global.Strophe = strophe.default.Strophe;
-global.b64_sha1 = strophe.default.b64_sha1;
 
-export { Strophe, $build, $iq, $msg, $pres, b64_sha1 } from './core';
+export { Strophe, $build, $iq, $msg, $pres } from './core';
+
+export const { b64_sha1 } = strophe.SHA1;

--- a/src/strophe.js
+++ b/src/strophe.js
@@ -10,5 +10,6 @@ global.$iq = strophe.default.$iq;
 global.$msg = strophe.default.$msg;
 global.$pres = strophe.default.$pres;
 global.Strophe = strophe.default.Strophe;
+global.b64_sha1 = strophe.default.b64_sha1;
 
-export { Strophe, $build, $iq, $msg, $pres } from './core';
+export { Strophe, $build, $iq, $msg, $pres, b64_sha1 } from './core';


### PR DESCRIPTION
strophejs-plugin-caps imports strophe.js' b64_sha1 function. This patch allows to use both of them in their latest version