### PR TITLE
fix(strophejs): provide disconnection timout

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1751,7 +1751,7 @@ Strophe.Connection = class Connection {
      *      certificate), set authcid to that same JID. See XEP-178 for more
      *      details.
      */
-    connect (jid, pass, callback, wait, hold, route, authcid, disconnectionTimeout) {
+    connect (jid, pass, callback, wait, hold, route, authcid, disconnectionTimeout = 3000) {
         this.jid = jid;
         /** Variable: authzid
          *  Authorization identity.
@@ -1773,7 +1773,7 @@ Strophe.Connection = class Connection {
         this.connected = false;
         this.authenticated = false;
         this.restored = false;
-        this.disconnectionTimeout = 3000;
+        this.disconnectionTimeout = disconnectionTimeout;
 
         // parse jid for domain
         this.domain = Strophe.getDomainFromJid(this.jid);

--- a/src/core.js
+++ b/src/core.js
@@ -1750,6 +1750,7 @@ Strophe.Connection = class Connection {
      *      (for example when the JID is already contained in the client
      *      certificate), set authcid to that same JID. See XEP-178 for more
      *      details.
+     *     (Number) disconnectionTimeout - The optional disconnection timeout
      */
     connect (jid, pass, callback, wait, hold, route, authcid, disconnectionTimeout = 3000) {
         this.jid = jid;

--- a/src/core.js
+++ b/src/core.js
@@ -1750,9 +1750,10 @@ Strophe.Connection = class Connection {
      *      (for example when the JID is already contained in the client
      *      certificate), set authcid to that same JID. See XEP-178 for more
      *      details.
-     *     (Number) disconnectionTimeout - The optional disconnection timeout
+     *     (Integer) disconnectionTimeout - The optional disconnection timeout 
+     *      in milliseconds before _doDisconnect will be called.
      */
-    connect (jid, pass, callback, wait, hold, route, authcid, disconnectionTimeout = 3000) {
+    connect (jid, pass, callback, wait, hold, route, authcid, disconnection_timeout = 3000) {
         this.jid = jid;
         /** Variable: authzid
          *  Authorization identity.
@@ -1774,7 +1775,7 @@ Strophe.Connection = class Connection {
         this.connected = false;
         this.authenticated = false;
         this.restored = false;
-        this.disconnectionTimeout = disconnectionTimeout;
+        this.disconnection_timeout = disconnection_timeout;
 
         // parse jid for domain
         this.domain = Strophe.getDomainFromJid(this.jid);
@@ -2357,7 +2358,7 @@ Strophe.Connection = class Connection {
             }
             // setup timeout handler
             this._disconnectTimeout = this._addSysTimedHandler(
-                this.disconnectionTimeout, this._onDisconnectTimeout.bind(this));
+                this.disconnection_timeout, this._onDisconnectTimeout.bind(this));
             this._proto._disconnect(pres);
         } else {
             Strophe.warn("Disconnect was called before Strophe connected to the server");

--- a/src/core.js
+++ b/src/core.js
@@ -1751,7 +1751,7 @@ Strophe.Connection = class Connection {
      *      certificate), set authcid to that same JID. See XEP-178 for more
      *      details.
      */
-    connect (jid, pass, callback, wait, hold, route, authcid) {
+    connect (jid, pass, callback, wait, hold, route, authcid, disconnectionTimeout) {
         this.jid = jid;
         /** Variable: authzid
          *  Authorization identity.
@@ -1773,6 +1773,7 @@ Strophe.Connection = class Connection {
         this.connected = false;
         this.authenticated = false;
         this.restored = false;
+        this.disconnectionTimeout = 3000;
 
         // parse jid for domain
         this.domain = Strophe.getDomainFromJid(this.jid);
@@ -2355,7 +2356,7 @@ Strophe.Connection = class Connection {
             }
             // setup timeout handler
             this._disconnectTimeout = this._addSysTimedHandler(
-                3000, this._onDisconnectTimeout.bind(this));
+                this.disconnectionTimeout, this._onDisconnectTimeout.bind(this));
             this._proto._disconnect(pres);
         } else {
             Strophe.warn("Disconnect was called before Strophe connected to the server");


### PR DESCRIPTION
Motivation:
it's better to provide a manageable disconnection timeout to customers instead of having a hardcoded one.

[our case]
in some cases, we have race conditions when we call disconnect(it has 3000ms timeout) and start reconnection. The reconnection is succeded in 1sec and then we have doDisconnect called.