### PR TITLE
fix(websocket): stringify websocket error

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -410,7 +410,7 @@ Strophe.Websocket = class Websocket {
      * (Object) error - The websocket error.
      */
     _onError (error) {
-        Strophe.error("Websocket error " + error);
+        Strophe.error("Websocket error " + JSON.stringify(error));
         this._conn._changeConnectStatus(
             Strophe.Status.CONNFAIL,
             "The WebSocket connection could not be established or was disconnected."


### PR DESCRIPTION
Motivation:
Websocket error messages look like [object Object]. It would be better to stringify the message to get real information about the cause.