### PR TITLE
fix(websocket): catch Websocket send error

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -434,10 +434,14 @@ Strophe.Websocket = class Websocket {
                     } else {
                         stanza = data[i];
                     }
-                    const rawStanza = Strophe.serialize(stanza);
-                    this._conn.xmlOutput(stanza);
-                    this._conn.rawOutput(rawStanza);
-                    this.socket.send(rawStanza);
+                    try {
+                      const rawStanza = Strophe.serialize(stanza);
+                      this._conn.xmlOutput(stanza);
+                      this._conn.rawOutput(rawStanza);
+                      this.socket.send(rawStanza);
+                    } catch (error) {
+                      Strophe.error("Websocket could not send stanza, error: " + JSON.stringify(error));
+                    }
                 }
             }
             this._conn._data = [];


### PR DESCRIPTION
Motivation:
catch error when websocket doesn't exist anymore but inner _onidle trying to send a message

[Case]
![image](https://user-images.githubusercontent.com/20629939/144464070-0a1bddb3-bad1-4091-9803-5e4a47f4590b.png)
