### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/sasl-sha1.js
+++ b/src/sasl-sha1.js
@@ -40,7 +40,7 @@ export default class SASLSHA1 extends SASLMechanism {
            }
        }
 
-       if (nonce.substr(0, cnonce.length) !== cnonce) {
+       if (nonce.slice(0, cnonce.length) !== cnonce) {
            connection._sasl_data = {};
            return connection._sasl_failure_cb();
        }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.