### PR TITLE
fix(bosh): mark first request dead when second is done

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -619,6 +619,9 @@ Strophe.Bosh = class Bosh {
             return;
         }
 
+        const reqIs0 = (this._requests[0] === req);
+        const reqIs1 = (this._requests[1] === req);
+
         const valid_request = reqStatus > 0 && reqStatus < 500;
         const too_many_retries = req.sends > this._conn.maxRetries;
         if (valid_request || too_many_retries) {
@@ -629,8 +632,6 @@ Strophe.Bosh = class Bosh {
 
         if (reqStatus === 200) {
             // request succeeded
-            const reqIs0 = (this._requests[0] === req);
-            const reqIs1 = (this._requests[1] === req);
             // if request 1 finished, or request 0 finished and request
             // 1 is over Strophe.SECONDARY_TIMEOUT seconds old, we need to
             // restart the other - both will be in the first spot, as the


### PR DESCRIPTION
Logic to restart first request if second finishes earlier doesn't work.
https://github.com/strophe/strophejs/blob/1877ecbcfd4da644219d06cb38083f92c1f92508/src/bosh.js#L634-L642

Request is never marked as dead in this case because we remove it on previous step.
https://github.com/strophe/strophejs/blob/1877ecbcfd4da644219d06cb38083f92c1f92508/src/bosh.js#L622-L628

This leads to long timeout instead of possible short secondary timeout in `_processRequest`

So we should save booleans before request is removed.
It was intended to work this way but did break on commit https://github.com/strophe/strophejs/commit/a7a14139c178ac3fad1fbd47b9a94aa880b0f126