### PR TITLE
Make only scram mandatory extensions abort connection

### DIFF
--- a/src/scram.js
+++ b/src/scram.js
@@ -48,8 +48,12 @@ function scramParseChallenge(challenge) {
             case 'i':
                 iter = parseInt(matches[2], 10);
                 break;
-            default:
+            case 'm':
+                // Mandatory but unknown extension, per RFC 5802 we should abort
                 return undefined;
+            default:
+                // Non-mandatory extension, per RFC 5802 we should ignore it
+                break;
         }
     }
 


### PR DESCRIPTION
I discovered this after adding support for xep-0474 in ejabberd which added` d=...` attribute to sasl challenge issued by ejabberd, and this causing problem with client using strophejs.

Per RFC5802 point 5.1 only attribute `m=...` should result in failure, all other unknown attributes should be ignored, but current version aborts connection when it find any unknown attribute. This pull request changes that to version suggested by RFC.