### PR TITLE
Fix use with nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
   "browser": "dist/strophe.umd.js",
   "module": "dist/strophe.esm.js",
   "unpkg": "dist/strophe.umd.min.js",
+  "exports": {
+    "node": {
+      "import": "./dist/strophe.esm.js",
+      "require": "./dist/strophe.common.js"
+    }
+  },
   "scripts": {
     "types": "tsc",
     "build": "rollup -c",

--- a/src/request.js
+++ b/src/request.js
@@ -71,7 +71,7 @@ class Request {
             log.debug('Got responseText but no responseXML; attempting to parse it with DOMParser...');
             node = new DOMParser().parseFromString(this.xhr.responseText, 'application/xml').documentElement;
 
-            const parserError = node?.querySelector('parsererror');
+            const parserError = node?.getElementsByTagName('parsererror').item(0);
             if (!node || parserError) {
                 if (parserError) {
                     log.error('invalid response received: ' + parserError.textContent);


### PR DESCRIPTION
[`xmldom`](https://github.com/xmldom/xmldom) does not implement querySelector so in nodejs an uncaught error can be triggered by running non-existant querySelector function

importing strophe.js from node_modules in nodejs by default uses the wrong file (src/index.js). The `exports` directive in `package.json` helps nodejs import (or require) the right file: https://nodejs.org/docs/latest-v20.x/api/packages.html#conditional-exports 

https://github.com/strophe/strophejs/issues/704 