### PR TITLE
Bugfix. Properly set `exports` value in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Strophe.js Change Log
 
+## Version 3.0.1 - (Unreleased)
+
+* Bugfix: `Package path . is not exported from package`
+
 ## Version 3.0.0 - (2024-05-07)
 
 * #704 Cannot use with NodeJS

--- a/package.json
+++ b/package.json
@@ -42,10 +42,7 @@
   "module": "dist/strophe.esm.js",
   "unpkg": "dist/strophe.umd.min.js",
   "exports": {
-    "node": {
-      "import": "./dist/strophe.esm.js",
-      "require": "./dist/strophe.common.js"
-    }
+    ".": "./src/index.js"
   },
   "scripts": {
     "types": "tsc",


### PR DESCRIPTION
Otherwise the following error appears when importing from Strophe:
```
Module not found: Error: Package path . is not exported from package
```

From what I can tell looking at the documentation (https://webpack.js.org/guides/package-exports), the previous values are invalid since they don't start with a `.`, so I removed them.

Leaving them in also caused this error:
```
Module not found: Error: Exports field key should be relative path and start with "." (key: "node")
```