### PR TITLE
Fix types minor errors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1021,7 +1021,7 @@ class Connection {
      * @param {string} ns - The namespace to match.
      * @param {string} name - The stanza name to match.
      * @param {string|string[]} type - The stanza type (or types if an array) to match.
-     * @param {string} id - The stanza id attribute to match.
+     * @param {string} [id] - The stanza id attribute to match.
      * @param {string} [from] - The stanza from attribute to match.
      * @param {HandlerOptions} [options] - The handler options
      * @return {Handler} A reference to the handler that can be used to remove it.

--- a/src/types/connection.d.ts
+++ b/src/types/connection.d.ts
@@ -947,12 +947,12 @@ declare class Connection {
      * @param {string} ns - The namespace to match.
      * @param {string} name - The stanza name to match.
      * @param {string|string[]} type - The stanza type (or types if an array) to match.
-     * @param {string} id - The stanza id attribute to match.
+     * @param {string} [id] - The stanza id attribute to match.
      * @param {string} [from] - The stanza from attribute to match.
      * @param {HandlerOptions} [options] - The handler options
      * @return {Handler} A reference to the handler that can be used to remove it.
      */
-    addHandler(handler: Function, ns: string, name: string, type: string | string[], id: string, from?: string, options?: {
+    addHandler(handler: Function, ns: string, name: string, type: string | string[], id?: string, from?: string, options?: {
         matchBareFromJid?: boolean;
         ignoreNamespaceFragment?: boolean;
     }): Handler;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -37,7 +37,7 @@ import { $pres } from './builder.js';
  * @property {Object.<string, string>} NS
  * @property {XHTML} XHTML
  */
-export const Strophe: {
+declare const Strophe: {
     shims: typeof shims;
     Request: typeof Request;
     Bosh: typeof Bosh;
@@ -221,5 +221,5 @@ import SASLMechanism from './sasl.js';
 import { Status } from './constants.js';
 import TimedHandler from './timed-handler.js';
 import * as utils from './utils.js';
-export { Builder, $build, $iq, $msg, $pres, Stanza, stx, toStanza, Request };
+export { Builder, $build, $iq, $msg, $pres, Stanza, stx, toStanza, Request, Strophe, Connection };
 //# sourceMappingURL=index.d.ts.map

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -37,7 +37,7 @@ import { $pres } from './builder.js';
  * @property {Object.<string, string>} NS
  * @property {XHTML} XHTML
  */
-declare const Strophe: {
+export const Strophe: {
     shims: typeof shims;
     Request: typeof Request;
     Bosh: typeof Bosh;
@@ -221,5 +221,5 @@ import SASLMechanism from './sasl.js';
 import { Status } from './constants.js';
 import TimedHandler from './timed-handler.js';
 import * as utils from './utils.js';
-export { Builder, $build, $iq, $msg, $pres, Stanza, stx, toStanza, Request, Strophe, Connection };
+export { Builder, $build, $iq, $msg, $pres, Stanza, stx, toStanza, Request, Connection };
 //# sourceMappingURL=index.d.ts.map


### PR DESCRIPTION
Hello,

First of all thanks for your hard work on the v3.0.0 !

I recently updated the deps in a project I work on, and `tsc` prompted some minor TS errors from Strophe.

So here is a quick PR to fix the errors encountered :

- In `connection.js` and `connection.d.ts`, at the `addHandler` method, the `id` parameter should be optional since it is already optional in `Handler.constructor`
- In `index.d.ts`, `Strophe` and `Connection` were added to the export, for simplicity purposes

Let me know if you need any changes on the PR.

Best regards !