### PR TITLE
fix: parentElement not always available depending on context

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -173,7 +173,8 @@ class Builder {
      * @return {Builder} The Strophe.Builder object.
      */
     up() {
-        this.node = this.node.parentElement;
+        // Depending on context, parentElement is not always available
+        this.node = this.node.parentElement ? this.node.parentElement : /** @type {Element} */ (this.node.parentNode);
         return this;
     }
 


### PR DESCRIPTION
Adding a check to use `parentNode` when `parentElement` is not available (eg. in some Web Workers contexts)

Closes #711