### PR TITLE
fix: invert default and types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
       "import": "./dist/strophe.esm.js",
       "require": "./dist/strophe.common.js"
     },
-    "default": "./src/index.js",
-    "types": "./src/types/index.d.ts"
+    "types": "./src/types/index.d.ts",
+    "default": "./src/index.js"
   },
   "scripts": {
     "types": "tsc",


### PR DESCRIPTION
When strophe.js is updated from v3.0.0 to v3.0.1 in a Next.js project (next@15.0.0-rc.0), the following build error appears:

```
Module not found: Default condition should be last one
```

Moving the default condition to the last position in the `exports` field fixes the issue.

