### PR TITLE
Fix: Handle Stream Error

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -121,7 +121,7 @@ class Websocket {
             errorString += ' - ' + text;
         }
         log.error(errorString);
-        // Call error handler
+        // The error is returned to the Strophe error method, allowing it to be handled.
         Strophe.error(errorString);
 
         // close the connection on stream_error

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -121,6 +121,8 @@ class Websocket {
             errorString += ' - ' + text;
         }
         log.error(errorString);
+        // Call error handler
+        Strophe.error(errorString);
 
         // close the connection on stream_error
         this._conn._changeConnectStatus(connectstatus, condition);


### PR DESCRIPTION
Strophe version 3.0.1 is unable to retrieve stream error details using the Strophe.error method. The existing functionality logs details only in the console.

If a stream error occurs, it needs to be handled as follows:

Strophe.error = (errorMsg: string) => {
  // My custom code
};