### PR TITLE
 Remove Deprecated abab Package and Switch to Native atob()/btoa() Methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "strophe.js",
       "version": "3.0.1",
       "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.3"
-      },
       "devDependencies": {
         "@babel/core": "^7.18.5",
         "@babel/eslint-parser": "^7.19.1",
@@ -2294,12 +2291,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead"
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -93,9 +93,6 @@
     "typescript": "^5.1.6",
     "xhr2": "^0.2.1"
   },
-  "dependencies": {
-    "abab": "^2.0.3"
-  },
   "optionalDependencies": {
     "@types/ws": "^8.5.5",
     "@xmldom/xmldom": "0.8.10",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default [
     // CommonJS (for Node) and ES module (for bundlers) build.
     {
         input: 'src/index.js',
-        external: ['window', 'abab'],
+        external: ['window'],
         output: [
             { file: 'dist/strophe.common.js', format: 'cjs' },
             { file: pkg.module, format: 'es' },

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,4 +1,3 @@
-import { atob, btoa } from 'abab';
 import Handler from './handler.js';
 import TimedHandler from './timed-handler.js';
 import Builder, { $build, $iq, $pres } from './builder.js';


### PR DESCRIPTION
**Description:**

This PR removes the deprecated `abab `package as it is no longer maintained. The functionality previously provided by `abab `is now replaced with the native `atob()` and `btoa()` methods available in the platform.

https://www.npmjs.com/package/abab

**Changes:**

Removed the `abab `package from dependencies.
Replaced usage of `abab `with the platform's native `atob()` and `btoa()` methods.
Reasoning:
The `abab `package has been deprecated, and using native methods improves performance and reduces external dependencies.

**Testing:**

Verified that the application works correctly with `atob()` and `btoa()` for encoding and decoding.
