### PR TITLE
[WIP] Support SASL2 FAST authentication

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -146,7 +146,7 @@ class Bosh {
 
         const body = this._buildBody().attrs({
             'to': this._conn.domain,
-            'from': this._conn.jid,
+            ...(this._conn.service.startsWith("https://") ? {'from': this._conn.jid}} : {}),
             'xml:lang': 'en',
             'wait': this.wait,
             'hold': this.hold,
@@ -452,7 +452,7 @@ class Bosh {
                     if (data[i] === 'restart') {
                         body.attrs({
                             'to': this._conn.domain,
-                            'from': this._conn.jid,
+                            ...(this._conn.service.startsWith("https://") ? {'from': this._conn.jid}} : {}),
                             'xml:lang': 'en',
                             'xmpp:restart': 'true',
                             'xmlns:xmpp': NS.BOSH,

--- a/src/bosh.js
+++ b/src/bosh.js
@@ -146,6 +146,7 @@ class Bosh {
 
         const body = this._buildBody().attrs({
             'to': this._conn.domain,
+            'from': this._conn.jid,
             'xml:lang': 'en',
             'wait': this.wait,
             'hold': this.hold,
@@ -451,6 +452,7 @@ class Bosh {
                     if (data[i] === 'restart') {
                         body.attrs({
                             'to': this._conn.domain,
+                            'from': this._conn.jid,
                             'xml:lang': 'en',
                             'xmpp:restart': 'true',
                             'xmlns:xmpp': NS.BOSH,

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,7 @@ export const NS = {
     DISCO_ITEMS: 'http://jabber.org/protocol/disco#items',
     MUC: 'http://jabber.org/protocol/muc',
     SASL: 'urn:ietf:params:xml:ns:xmpp-sasl',
+    SASL2: 'urn:xmpp:sasl:2',
     STREAM: 'http://etherx.jabber.org/streams',
     FRAMING: 'urn:ietf:params:xml:ns:xmpp-framing',
     BIND: 'urn:ietf:params:xml:ns:xmpp-bind',

--- a/src/fast.js
+++ b/src/fast.js
@@ -1,0 +1,280 @@
+/**
+ * @typedef {import("./connection.js").default} Connection
+ */
+import SASLMechanism from './sasl.js';
+import { ElementType, Status } from './constants.js';
+import {
+    getBareJidFromJid,
+    getText
+} from './utils.js';
+
+const SASL2 = {
+    // TODO: turn this into a full module
+    'NS': 'urn:xmpp:sasl:2'
+}
+
+/**
+ * @this {{ conn: Connection }}
+ */
+const FAST = {
+    NS: 'urn:xmpp:fast:0',
+
+    /** @type {Connection} */
+    conn: null,
+
+    /**
+     * @typedef {Object} FastToken
+     * @property {string} [mechanism]
+     * @property {string} [token]
+     * @property {Number} [expiry]
+     * @property {Number} [counter] 
+     */
+
+    /** @type {FastToken} */
+    token: null,
+
+    // Mechanisms supported by both us and the server
+    /** @type {String[]} } */
+    mechanisms: null,
+
+    // The **active** mechanism
+    /** @type {String} */
+    mechname: null,
+
+    /**
+     * Create and initialize a new Handler.
+     *
+     * @param {Connection} connection 
+     */
+    init: function (connection) {
+        this.conn = connection
+        this.mechanisms = []
+
+        // XXX messy; should be up in Converse.JS
+        let jid = getBareJidFromJid(localStorage.getItem("strophe-jid"));
+        if (!this.jid || (jid === getBareJidFromJid(this.jid)) && !this.token) {
+            this.conn.jid = jid;
+            let _token = localStorage.getItem(`strophe-fast-token:${jid}`)
+            if (_token) {
+                this.token = JSON.parse(_token)
+                console.log("Loaded", this.token, "from localStorage")
+            }
+        }
+
+        this._auth = this._auth.bind(this)
+        this.test = this.test.bind(this)
+    },
+
+    /**
+     * 
+     * @param {Number} status 
+     */
+    statusChanged: function (status) {
+        // init doesn't actually init: handlers get cleared at connection time,
+        // or at least, ConverseJS clears them then
+        // the safe place to do init is here, which is special-cased in connection.js
+
+
+        // Register listeners before we get data (CONNECTING) so
+        // we can catch the crucial first stanzas but actually do
+        // auth only once we get to AUTHENTICATING because that
+        // needs the basic infrastructure of the stream/session to be set up
+
+        if (status === Status.CONNECTING) {
+
+            //Strophe.addNamespace('FAST', 'urn:xmpp:fast:0') // TODO: load this plugin in a more sensible way
+
+            console.warn("FAST: .onConnecting")
+            // TODO: make this re-entrant, i.e. either always delete and recreate or track if our handler has been assigned
+            this.conn._addSysNSHandler(this.onSuccess.bind(this), SASL2.NS, 'success');
+            this.conn._addSysNSHandler(this.onChallenge.bind(this), SASL2.NS, 'challenge');
+            this.conn._addSysNSHandler(this.onFailure.bind(this), SASL2.NS, 'failure');
+
+            this.conn._addSysNSHandler(this.onAuth.bind(this), this.NS, 'fast');
+            this.conn._addSysNSHandler(this.onToken.bind(this), this.NS, 'token');
+
+            console.warn("/FAST: .onConnecting")
+            // the less disruptive way to design this, instead of hacking the core match logic:
+            // - set up a sasl2 module that hooks the top level <authentication>, <success>, <challenge>, <continue>, <failure> stanzas
+            // - provide an events API *in there* (using that .on() library?)
+            // - fast hooks into the events API
+            //
+            // or, even less invasive:
+            //
+            // - hook the top level SASL2 stanzas we know we need to look for here (namely: <success> and <authentication>)
+            //   and just parse them, as connection.js does for SASLv1
+            //
+            //  but always:
+            // - still hack the core logic to allow hooking the first stanza, that's important for auth
+            //
+        } else if (status === Status.AUTHENTICATING) {
+
+            // console.warn("FAST: .onAuthenticating")
+            // this._auth().then(() => {
+
+            //     console.warn("/FAST: .onAuthenticating")
+            // }).catch((err) => console.error(err));
+        }
+    },
+
+
+    // TODO: pull these to a SASL2 module
+    /**
+     * @param {Element} elem 
+     */
+    onSuccess: function (elem) {
+        const username = getText(elem.getElementsByTagName('authorization-identifier')[0])
+        console.info(`SASL2: authenticated as ${username}`, elem)
+        this.conn.authenticated = true;
+
+        // XXX messy; should be up in Converse.JS
+        let jid = getBareJidFromJid(this.conn.jid)
+        localStorage.setItem("strophe-jid", jid)
+        localStorage.setItem(`strophe-fast-token:${jid}`, JSON.stringify(this.token)); // disabled for debugging
+
+        console.log("saved", this.token, "to localStorage")
+
+        return true; // keep listening
+    },
+    /**
+     * @param {Element} elem 
+     */
+    onChallenge: function (elem) {
+        console.debug("SASL2: challenge received:", elem)
+        return true; // keep listening
+    },
+    /**
+     * @param {Element} elem 
+     */
+    onFailure: function (elem) {
+        console.info("SASL2: authentication failed", elem)
+        this.conn.authenticated = false;
+        return true; // keep listening
+    },
+
+    /**
+     * @param {Element} elem 
+     */
+    onAuth: function (elem) {
+        const sasl2_fast_offers = [...elem.querySelectorAll('mechanism')]
+            .map((m) => m.textContent);
+
+        //* @var {Set<String>} sasl2_fast_matched */
+        let sasl2_fast_matched = (new Set(sasl2_fast_offers)).intersection(new Set(Object.keys(this.conn.mechanisms)));
+
+        this.mechanisms = [...sasl2_fast_matched]
+        console.info(
+            "FAST: server advertised ", sasl2_fast_offers,
+            " of which we support", this.mechanisms);
+        if (this.mechanisms.length == 0) {
+            console.warn("FAST offered but with no known mechanisms.");
+            return
+        }
+
+        if (this.token && sasl2_fast_matched.has(this.token.mechanism)) {
+            // prefer the method of our current token, if we have it
+            this.mechname = this.token.mechanism;
+        } else {
+            // pick the first one
+            this.mechname = this.mechanisms[0]
+        }
+
+        console.info(`FAST: chose ${this.mechname}`);
+
+        // TODO: we need a way to edit outgoing stanzas too to tack the 'request-token' bit onto the backs of other auths..
+        // but how? Is there an outgoing listeners system?
+
+        return true;
+    },
+
+    test: function () {
+        // this is janky
+        return (this.token?.mechanism && this.mechname
+            && new Set(this.mechanisms).has(this.token.mechanism)
+            && this.conn.mechanisms[this.mechname].test(this.conn))
+    },
+    _auth: async function () {
+        console.warn("fast._auth()")
+        // and attempt to authenticate with it
+        console.info("FAST: attempting login")
+        let initial_response = await this.conn.mechanisms[this.mechname].clientChallenge(this.conn, null);
+        if (initial_response == false) {
+            console.warn(`FAST ${this.mechname} refused to provide an <initial-response>`)
+        }
+        initial_response = btoa(initial_response)
+        console.info("initial response", initial_response)
+        const authenticate = $build('authenticate', {
+            'xmlns': SASL2.NS,
+            'mechanism': this.mechname,
+        }).c('initial-response', null,
+            initial_response)
+            .up()
+
+            // > MUST also provide the a SASL2 <user-agent> element with an 'id' attribute
+            // > (both of these values are discussed in more detail in XEP-0388).
+            // - https://xmpp.org/extensions/xep-0484.html#rules-clients
+            .c('user-agent', {
+                // TODO: *this should be cached* in browser storage; else it will appear like hundreds of devices are connected to one's account
+                'id': "111222333444" //this.conn.getUniqueId("useragent")
+            })
+            .c("software", "Strophe.js").up()
+            .c("device", "MacBook").up()
+            .up().c("fast", {
+                // replay protection
+                // > Servers MUST reject any authentication requests received via
+                // > TLS 0-RTT payloads that do not include a 'count' attribute
+                // - https://xmpp.org/extensions/xep-0484.html#fast-auth
+                'count': this.token.counter.toString(),
+                'xmlns': this.NS,
+            })
+
+        let t = authenticate.tree()
+        console.error("Senidng FAST AUTH", t)
+        this.conn.send(t);
+        console.error("/Senidng FAST AUTH", t)
+
+        this.token.counter++;
+
+        return new Promise((resolve, reject) => {
+            this.conn._addSysHandler((elem /** {Element} */) => {
+                console.log("FAST: succeeded", elem)
+                // check that this.conn.jid == elem.jid.text?
+                resolve(elem)
+                false; // stop listening
+            }, SASL2.NS, 'success', null, null)
+            this.conn._addSysHandler((elem /** {Element} */) => {
+                console.warn("FAST: token login failed; invalidating current token", elem)
+                reject(elem)
+
+                // AND invalidate creds
+                // That means the user will drop back to the login page
+                // and then have to try again with a password
+                let jid = getBareJidFromJid(this.conn.jid)
+                //localStorage.removeItem(`strophe-fast-token:${jid}`)
+                this.token = null;
+
+                console.log("cleared", this.token, "from localStorage")
+            }, SASL2.NS, 'failure', null, null)
+        });
+
+    },
+
+    /**
+     * @param {Element} elem 
+     */
+    onToken: function (elem) {
+        console.log("fast plugin onToken", elem)
+        console.log(this)
+
+        this.token = {
+            'mechanism': this.mechname,
+            'token': elem.getAttribute('token'),
+            'expiry': Date.parse(elem.getAttribute('expiry')),
+            'counter': 0
+        };
+        let v = 1;
+        return true;
+    }
+};
+
+export default FAST;

--- a/src/handler.js
+++ b/src/handler.js
@@ -13,7 +13,43 @@ import { getBareJidFromJid, handleError, isTagEqual } from './utils.js';
  * will use {@link Connection.addHandler} and
  * {@link Connection.deleteHandler}.
  */
-class Handler {
+
+export class NSHandler {
+
+    /**
+     * Create and initialize a new NSHandler.
+     *
+     * @param {Function} handler - A function to be executed when the handler is run.
+     * @param {string} ns - The namespace to match.
+     * @param {string} name - The element name to match.
+     */
+    constructor(handler, ns, name) {
+        this.handler = handler;
+        this.ns = ns;
+        this.name = name;
+        // whether the handler is a user handler or a system handler
+        this.user = true;
+    }
+
+
+    /**
+     * Run the callback on a matching stanza.
+     * @param {Element} elem - The DOM element that triggered the Handler.
+     * @return {boolean} - A boolean indicating if the handler should remain active.
+     */
+    run(elem) {
+        let result = null;
+        try {
+            result = this.handler(elem);
+        } catch (e) {
+            handleError(e);
+            throw e;
+        }
+        return result;
+    }
+}
+
+export class Handler {
     /**
      * @typedef {Object} HandlerOptions
      * @property {boolean} [HandlerOptions.matchBareFromJid]
@@ -131,4 +167,4 @@ class Handler {
     }
 }
 
-export default Handler;
+export default { Handler, NSHandler };

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import SASLSHA256 from './sasl-sha256.js';
 import SASLSHA384 from './sasl-sha384.js';
 import SASLSHA512 from './sasl-sha512.js';
 import SASLXOAuth2 from './sasl-xoauth2.js';
+import FAST from './fast.js';
 import TimedHandler from './timed-handler.js';
 import Websocket from './websocket.js';
 import WorkerWebsocket from './worker-websocket.js';
@@ -189,5 +190,10 @@ globalThis.stx = stx;
 
 const toStanza = Stanza.toElement;
 globalThis.toStanza = Stanza.toElement; // Deprecated
+
+// XXX hack to break the circular dependency
+// the encouraged way to do plugins is to import them all in your app along with Strophe as a peer
+Strophe.addConnectionPlugin('fast', FAST);
+Strophe.addNamespace('FAST', 'urn:xmpp:fast:0')
 
 export { Builder, $build, $iq, $msg, $pres, Strophe, Stanza, stx, toStanza, Request };

--- a/src/sasl-ht-sha256-none.js
+++ b/src/sasl-ht-sha256-none.js
@@ -1,0 +1,63 @@
+/**
+ * @typedef {import("./types/connection.js").default} Connection
+*/
+import SASLMechanism from './sasl.js';
+import {
+    getNodeFromJid,
+} from './utils.js';
+// TODO: factor this and do the other methods defined in https://datatracker.ietf.org/doc/draft-schmaus-kitten-sasl-ht/09/
+// import ht from './ht.js';
+
+class SASLHTSHA256NONE extends SASLMechanism {
+    /**
+     * SASL HT SHA 256 authentication.
+     */
+    constructor(mechname = 'HT-SHA-256-NONE', isClientFirst = true, priority = 75) {
+        super(mechname, isClientFirst, priority);
+    }
+
+    /**
+     * @param {Connection} connection
+     */
+    // eslint-disable-next-line class-methods-use-this
+    test(connection) {
+        let T = (connection.fast?.token?.mechanism == this.mechname)
+            && (Date.now() < connection.fast?.token?.expiry - 30); // -30 for some wiggle room in clock skew etc
+
+        return true;
+    }
+
+    /**
+     * @param {Connection} connection
+     * @param {string} [challenge]
+     */
+    // eslint-disable-next-line class-methods-use-this
+    onChallenge(connection, challenge) {
+        throw new Error("Hashed-Token methods do not respond to challenges");
+    }
+
+    /**
+     * @param {Connection} connection
+     * @param {string} [test_cnonce]
+     */
+    // eslint-disable-next-line class-methods-use-this
+    async clientChallenge(connection, test_cnonce) {
+        // from https://github.com/xmppjs/xmpp.js/blob/d01b2f1dcb81c7d2880d1021ca352256675873a4/packages/sasl-ht-sha-256-none/index.js#L12
+        const key = await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(connection.fast?.token?.token),
+            // https://developer.mozilla.org/en-US/docs/Web/API/HmacImportParams
+            { name: "HMAC", hash: "SHA-256" },
+            false, // extractable
+            ["sign", "verify"],
+        )
+        const signature = await crypto.subtle.sign(
+            "HMAC",
+            key,
+            new TextEncoder().encode("Initiator"),
+        )
+        return `${getNodeFromJid(connection.jid)}\0${String.fromCodePoint(...new Uint8Array(signature))}`;
+    }
+}
+
+export default SASLHTSHA256NONE;

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -67,6 +67,7 @@ class Websocket {
         return $build('open', {
             'xmlns': NS.FRAMING,
             'to': this._conn.domain,
+            ...((this._conn.service.startsWith("wss") || this._conn.service.startsWith("ws://localhost")) ? { 'from': this._conn.jid } : {}),
             'version': '1.0',
         });
     }


### PR DESCRIPTION
FAST is a cookie-style authentication method that
lets clients store and auth with an unguesseable token. It enables clients to forget the user's full password, which is especially important for web-based clients, that are prone to data leaks. Leaked tokens can be invalidated.

- https://xmpp.org/extensions/xep-0484.html
- https://xmpp.org/extensions/xep-0388.html

Very messy, but I'm sharing for feedback.
Intended to fix https://github.com/conversejs/converse.js/issues/3144

Some aside changes I needed for this:
- I let handlers listen to the *opening* stanza
- Set 'from' on the opening <stream> tag. (ref: https://github.com/xmppjs/xmpp.js/pull/1006/files#r1893267922)
- Create a new handler type (I know, I know) that can search *nested data*. This made setting up listeners a lot more convenient.
- Rearrange
- During connection, replaced has_features with the direct XML element ?. liberally. That seems more direct and defensive.
- Moved Status.AUTHENTICATING before FAST/SASL

I think the SASL negotiation logic can be cleaned up a lot, It could handle fallback through all the methods, instead of needing awkward special cases for FAST. Allowing handlers to hear the opening stanza means, I am pretty sure, all of SASL2 can become an event-driven plugin, and maybe all of SASL1.

Things that are bad:
- too much copy-pasting
- the SASL negotiation is brittle and only makes and tries one decision except for FAST which is bodged in awkwardly
- saving/loading the FAST tokens is to be defined I coded something directly in here but really clients need to be making that decision (xmpp.js provided overridable methods to fill with localStorage or a cookie or something)
- NSHandler was a whim of fancy. It should probably be backed out. Allowing searching for *nested* namespaces/tags (which most other xmpp libraries do?) tidies the code a lot, but I recognize it's offtopic, and there are more verbose ways to achieve FAST without them.
- websocket checks for 'secure' before sending 'from', but bosh doesn't yet.
- support the other HT- methods from the spec
- pull SASL2 into sasl2.js and make it a plugin
- load fast.js as a proper plugin instead of importing it in index.js. I did this for testing, so I wouldn't have to mess around too much with ConverseJS.
- Needs to disentangle the circular dependencies between a plugin and code that needs to run during the early boot.
- It doesn't support the `invalidate=1`option, and it's actually just fully impossible to log out (without digging around in the web debugger anyway)