### PR TITLE
Support SASL2 FAST authentication

### DIFF
--- a/src/bosh.js
+++ b/src/bosh.js
@@ -146,6 +146,7 @@ class Bosh {
 
         const body = this._buildBody().attrs({
             'to': this._conn.domain,
+            ...(this._conn.service.startsWith("https://") ? { 'from': this._conn.jid } : {}),
             'xml:lang': 'en',
             'wait': this.wait,
             'hold': this.hold,
@@ -451,6 +452,7 @@ class Bosh {
                     if (data[i] === 'restart') {
                         body.attrs({
                             'to': this._conn.domain,
+                            ...(this._conn.service.startsWith("https://") ? { 'from': this._conn.jid } : {}),
                             'xml:lang': 'en',
                             'xmpp:restart': 'true',
                             'xmlns:xmpp': NS.BOSH,

--- a/src/connection.js
+++ b/src/connection.js
@@ -1619,14 +1619,12 @@ class Connection {
 
         if (this._sasl_data['server-signature']) {
 
-            console.debug("sasl success: checking final signature")
             let success;
             if (elem.namespaceURI == NS.SASL2) {
                 success = elem.querySelector('additional-data')
             } else if (elem.namespaceURI == NS.SASL) {
                 success = elem;
             } else {
-                console.error(`Unsupported namespace ${elem.namespaceURI}, cannot authenticate server.`)
                 return this._sasl_failure_cb(elem);
             }
 
@@ -1634,7 +1632,6 @@ class Connection {
                 // but I've enabled fall-through to multiple SASL methods so I need to revamp when 'server-signature' gets set
 
                 success = atob(getText(success))
-                console.debug("sasl success: final signature is", success)
 
                 const attribMatch = /([a-z]+)=([^,]+)(,|$)/;
                 const matches = success.match(attribMatch);
@@ -1650,12 +1647,11 @@ class Connection {
                         this._sasl_challenge_handler = null;
                     }
                     this._sasl_data = {};
-                    console.error("Final SASL signature check failed")
                     return this._sasl_failure_cb(elem);
                 }
             }
         }
-        console.log('SASL authentication succeeded.');
+        log.info('SASL authentication succeeded.');
 
         if (elem.namespaceURI == NS.SASL2) {
             // TODO: do something useful with this?

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ import SASLSHA256 from './sasl-sha256.js';
 import SASLSHA384 from './sasl-sha384.js';
 import SASLSHA512 from './sasl-sha512.js';
 import SASLXOAuth2 from './sasl-xoauth2.js';
+import SASL2 from './sasl2.js';
+import FAST from './sasl2_fast.js';
 import TimedHandler from './timed-handler.js';
 import Websocket from './websocket.js';
 import WorkerWebsocket from './worker-websocket.js';
@@ -189,5 +191,15 @@ globalThis.stx = stx;
 
 const toStanza = Stanza.toElement;
 globalThis.toStanza = Stanza.toElement; // Deprecated
+
+
+// XXX hack to break the circular dependency
+// the encouraged way to do plugins is to import them all in your app along with Strophe as a peer
+Strophe.addConnectionPlugin('sasl2', SASL2);
+Strophe.addNamespace('SASL2', SASL2.NS);
+
+Strophe.addConnectionPlugin('fast', FAST);
+Strophe.addNamespace('FAST', FAST.NS);
+
 
 export { Builder, $build, $iq, $msg, $pres, Strophe, Stanza, stx, toStanza, Request };

--- a/src/sasl-ht-sha256-none.js
+++ b/src/sasl-ht-sha256-none.js
@@ -1,0 +1,61 @@
+/**
+ * @typedef {import("./types/connection.js").default} Connection
+*/
+import SASLMechanism from './sasl.js';
+import {
+    getNodeFromJid,
+} from './utils.js';
+// TODO: factor this and do the other methods defined in https://datatracker.ietf.org/doc/draft-schmaus-kitten-sasl-ht/09/
+// import ht from './ht.js';
+
+class SASLHTSHA256NONE extends SASLMechanism {
+    /**
+     * SASL HT SHA 256 authentication.
+     */
+    constructor(mechname = 'HT-SHA-256-NONE', isClientFirst = true, priority = 75) {
+        super(mechname, isClientFirst, priority);
+    }
+
+    /**
+     * @param {Connection} connection
+     */
+    // eslint-disable-next-line class-methods-use-this
+    test(connection) {
+        return (connection.fast?.credential?.mechanism == this.mechname)
+            && (Date.now() < connection.fast?.credential?.expiry - 30); // -30 for some wiggle room in clock skew etc
+    }
+
+    /**
+     * @param {Connection} connection
+     * @param {string} [challenge]
+     */
+    // eslint-disable-next-line class-methods-use-this
+    onChallenge(connection, challenge) {
+        throw new Error("Hashed-Token methods do not respond to challenges");
+    }
+
+    /**
+     * @param {Connection} connection
+     * @param {string} [test_cnonce]
+     */
+    // eslint-disable-next-line class-methods-use-this
+    async clientChallenge(connection, test_cnonce) {
+        // from https://github.com/xmppjs/xmpp.js/blob/d01b2f1dcb81c7d2880d1021ca352256675873a4/packages/sasl-ht-sha-256-none/index.js#L12
+        const key = await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(connection.fast?.credential?.token),
+            // https://developer.mozilla.org/en-US/docs/Web/API/HmacImportParams
+            { name: "HMAC", hash: "SHA-256" },
+            false, // extractable
+            ["sign", "verify"],
+        )
+        const signature = await crypto.subtle.sign(
+            "HMAC",
+            key,
+            new TextEncoder().encode("Initiator"),
+        )
+        return `${getNodeFromJid(connection.jid)}\0${String.fromCodePoint(...new Uint8Array(signature))}`;
+    }
+}
+
+export default SASLHTSHA256NONE;

--- a/src/sasl-sha1.js
+++ b/src/sasl-sha1.js
@@ -17,7 +17,7 @@ class SASLSHA1 extends SASLMechanism {
      */
     // eslint-disable-next-line class-methods-use-this
     test(connection) {
-        return connection.authcid !== null;
+        return scram.test(connection, 'SHA-1', 160);
     }
 
     /**

--- a/src/sasl-sha256.js
+++ b/src/sasl-sha256.js
@@ -17,7 +17,7 @@ class SASLSHA256 extends SASLMechanism {
      */
     // eslint-disable-next-line class-methods-use-this
     test(connection) {
-        return connection.authcid !== null;
+        return scram.test(connection, 'SHA-256', 256);
     }
 
     /**

--- a/src/sasl-sha384.js
+++ b/src/sasl-sha384.js
@@ -17,7 +17,7 @@ class SASLSHA384 extends SASLMechanism {
      */
     // eslint-disable-next-line class-methods-use-this
     test(connection) {
-        return connection.authcid !== null;
+        return scram.test(connection, 'SHA-384', 384);
     }
 
     /**

--- a/src/sasl-sha512.js
+++ b/src/sasl-sha512.js
@@ -17,7 +17,7 @@ class SASLSHA512 extends SASLMechanism {
      */
     // eslint-disable-next-line class-methods-use-this
     test(connection) {
-        return connection.authcid !== null;
+        return scram.test(connection, 'SHA-512', 512);
     }
 
     /**

--- a/src/sasl2.js
+++ b/src/sasl2.js
@@ -1,0 +1,234 @@
+/**
+ * @typedef {import("./connection.js").default} Connection
+ */
+import { Status } from './constants.js';
+import { getText } from './utils.js';
+
+const SASL2 = {
+    // TODO: turn this into a full module
+    'NS': 'urn:xmpp:sasl:2',
+
+    /** @type {Connection} */
+    conn: null,
+
+    /**
+     * Create and initialize a new Handler.
+     *
+     * @param {Connection} connection 
+     */
+    init: function (connection) {
+        this.conn = connection;
+
+        // generate a new ephemeral client ID for <user-agent> stanza
+        // XXX note that if using FAST this is *non* ephemeral:
+        // it is the username and the FAST token is the password
+        this.clientID = this.conn.getUniqueId();
+    },
+
+    /**
+     * 
+     * @param {Number} status 
+     */
+    statusChanged: function (status) {
+
+        console.warn("statusChanged:", status)
+
+        if (status == Status.CONNECTING) {
+
+            // Register listeners *before* we read any data (CONNECTING)
+            // so we can catch the crucial first stanzas 
+
+            // This listener doesn't work with the normal Strophe handlers because
+            // 1. <stream:features> is special-cased in connection.js and not passed to handlers
+            // 2. addSysHandler() can only hook top-level tags, but <authentication> is nested in <stream:features>
+            // TODO: rewrite more verbosely using addSysHandler. If possible.
+            this.conn._addSysNSHandler(
+                this.onAuth.bind(this),
+                this.NS,
+                'authentication'
+            )
+        }
+    },
+
+    /**
+     * @param {Element} elem 
+     */
+    onAuth: async function (elem) {
+        const server_mechanisms = [...elem.querySelectorAll('mechanism')]
+            .map((m) => m.textContent);
+
+        /** @type {String[]} } */
+        this.mechanisms = [...
+            new Set(server_mechanisms)
+                .intersection(new Set(Object.keys(this.conn.mechanisms)))
+        ];
+
+        console.info(
+            "SASL2: server advertised ", server_mechanisms,
+            " of which we support", this.mechanisms);
+        if (this.mechanisms.length == 0) {
+            console.warn("FAST offered but with no known mechanisms.");
+        }
+
+        return false; // stop listening
+    },
+
+    async authenticateStanza(/** @type String */ mechname) {
+        const authenticate = $build('authenticate', {
+            'xmlns': this.NS,
+            'mechanism': mechname,
+        });
+
+        authenticate
+            .c('user-agent', { 'id': this.clientID })
+            .c("software", "Strophe.js").up()
+            .c("device", navigator?.userAgent ?? "").up()
+            .up();
+
+        return authenticate
+    },
+
+    authenticate: async function () {
+        if (this.conn.authenticated) {
+            console.warn("SASL2: Already authenticated; not authenticating again.");
+            return
+        }
+
+        // sort by priority
+        this.mechanisms.sort((a, b) => {
+            return (this.conn.mechanisms[b].priority - this.conn.mechanisms[a].priority)
+        })
+
+        for (let mechname of this.mechanisms) {
+
+            let mechanism = this.conn.mechanisms[mechname]
+            if (!mechanism) {
+                console.warn(`SASL2: Unknown mechanism ${mechname}`)
+            }
+            if (!mechanism.test(this.conn)) {
+                console.debug("SASL2: skipping mechanism", mechname)
+                continue
+            }
+            console.debug("SASL2: trying mechanism", mechname)
+
+            if (await this._authenticate(mechname)) {
+                this.conn.authenticated = true;
+                console.debug("SASL 2 mechanism", mechname, "succeded")
+                return true;
+            } else {
+                console.debug("SASL 2 mechanism", mechname, "failed")
+                // return false ; // *stop* fallback
+            }
+        }
+
+        return false;
+    },
+
+    _authenticate: async function (mechname) {
+        let mechanism = this.conn.mechanisms[mechname]
+        if (!mechanism) {
+            console.warn(`SASL2: Unknown mechanism ${mechname}`)
+        }
+        if (!mechanism.test(this.conn)) {
+            return false
+        }
+        this.conn._sasl_mechanism = mechanism; // backwards compat
+
+        // wrap Strophe's callback-based API into a deferred Promise
+        let resolve_sasl_response
+        /** @type Promise<Element> */
+        let _response = new Promise((resolve, _) => {
+
+            resolve_sasl_response = resolve
+        })
+
+        let success_handler = this.conn._addSysHandler(
+            (elem) => resolve_sasl_response(elem),
+            this.NS,
+            'success',
+            null,
+            null
+        );
+        let failure_handler = this.conn._addSysHandler(
+            (elem) => resolve_sasl_response(elem),
+            this.NS,
+            'failure',
+            null,
+            null
+        );
+        let challenge_handler = this.conn._addSysHandler(
+            (elem) => resolve_sasl_response(elem),
+            this.NS,
+            'challenge',
+            null,
+            null
+        );
+
+        const clear_handlers = () => {
+            if (success_handler) {
+                this.conn.deleteHandler(success_handler);
+                success_handler = null
+            }
+            if (failure_handler) {
+                this.conn.deleteHandler(failure_handler);
+                failure_handler = null
+            }
+            if (challenge_handler) {
+                this.conn.deleteHandler(challenge_handler);
+                challenge_handler = null
+            }
+        }
+
+        // delay to allow the idle loop to reliably install the new handlers
+        await Promise.resolve();
+
+        // fast needs to modify non-fast <authenticate>s
+        // and needs to change the format slightly for FAST <authenticate>s
+
+        let authenticate = await this.authenticateStanza(mechname)
+
+        mechanism.onStart(this.conn);
+        if (mechanism.isClientFirst) {
+            const response = await mechanism.clientChallenge(this.conn);
+            authenticate
+                .c('initial-response',
+                    null,
+                    btoa(/** @type {string} */(response)))
+                .up();
+        }
+        console.debug("SASL2: sending <authenticate>", authenticate.tree())
+        this.conn.send(authenticate.tree());
+        try {
+            while (true) { // SASL loops, sending [ <challenge> <response> ... ] until <success>
+
+                const response = await _response;
+                console.debug(`SASL2: <${response.tagName}>:`, response)
+
+                if (response.tagName == 'challenge') {
+                    this.conn._sasl_challenge_cb.bind(this.conn)(response); // this callback replies to the server with a <response>
+                } else if (response.tagName == 'success') {
+                    this.conn._sasl_success_cb.bind(this.conn)(response); // this callback verifies the server's final <additional-data>
+                    return true
+                } else if (response.tagName == 'failure') {
+                    this.conn._sasl_failure_cb.bind(this.conn)(response); // this sends an error event up the stack
+                    return false
+                } else {
+                    throw new Exception("Unknown SASL2 response:", response)
+                }
+
+                // reset the deferred promise
+                _response = new Promise(resolve => {
+                    resolve_sasl_response = resolve
+                })
+            }
+        } catch (e) {
+            console.error(e);
+            throw e;
+        } finally {
+            clear_handlers()
+        }
+
+    },
+};
+
+export default SASL2;

--- a/src/sasl2.js
+++ b/src/sasl2.js
@@ -2,7 +2,6 @@
  * @typedef {import("./connection.js").default} Connection
  */
 import { Status } from './constants.js';
-import { getText } from './utils.js';
 
 const SASL2 = {
     // TODO: turn this into a full module

--- a/src/sasl2_fast.js
+++ b/src/sasl2_fast.js
@@ -1,0 +1,239 @@
+/**
+ * @typedef {import("./connection.js").default} Connection
+*/
+import { Status } from './constants.js';
+
+/**
+ * @typedef {Object} FastCredential
+ * @property {string} [clientID] 
+ * @property {string} [mechanism]
+ * @property {string} [token]
+ * @property {Number} [expiry]
+ * @property {Number} [counter] 
+ */
+
+/**
+ * @this {{ conn: Connection }}
+ */
+const FAST = {
+    NS: 'urn:xmpp:fast:0',
+
+    /** @type {Connection} */
+    conn: null,
+
+    // Mechanisms supported by both us and the server
+    // note that there are SASL2 mechanisms and then SASL2-FAST mechanisms
+    // it's nested in a <internal><fast>...</fast></internal>
+    // we merge the two, but the server sends them separately,
+    // and those in *this* subset are ones we respond with our own <fast> tag.
+    /** @type {String[]} } */
+    mechanisms: null,
+
+    /** @type {FastCredential} */
+    credential: null,
+
+    /**
+     * Create and initialize a new Handler.
+     *
+     * @param {Connection} connection 
+     */
+    init: function (connection) {
+        this.conn = connection
+
+        this.credential = {
+            'clientID': this.conn.sasl2.clientID,
+        }
+
+        // **monkey-patch** SASL2 to add
+        // - FAST <fast> to outgoing <authenticate>s using a FAST mechanism
+        // - FAST <request-token> other outgoing <authenticate>s
+        //
+        // (XXX: a better solution would be an _outgoing_ handler system)
+        //
+        // TODO: for completeness, test that it's possible to use a FAST
+        // <authenticate> with one mechanism to <request-token> for a different
+        // e.g. it should be legal and possible to send
+        //   <authenticate mechanism="HT-SHA-512-ENDP"><request-token mechanism="HT-SHA-256-NONE" /></authenticate>
+
+        const authenticateStanza = this.conn.sasl2.authenticateStanza.bind(this.conn.sasl2) // XXX is the .bind() necessary?
+        this.conn.sasl2.authenticateStanza = async (mechname) => {
+            let authenticate = await authenticateStanza(mechname);
+
+            // Try to authenticate with FAST
+            // The protocol here is subtly different. The *implicit assumption* is that
+            // that the <fast> and the <challenge>/<response> mechanisms do not overlap.
+            if (/* mechname is in fact accepted by the server as a FAST mechanism */
+                this.mechanisms.indexOf(mechname) != -1 &&
+                /* AND we have a token for it */
+                this.credential?.mechanism == mechname) {
+
+                if (!this.credential.token) {
+                    // mechanism.test() shouldn't have let us get here
+                    throw new Exception(`Tried to authenticate with FAST mechanism ${mechname} without fast.credential being defined`);
+                }
+
+                // > To indicate that it is providing a token, the client MUST
+                // > include a <fast/> element qualified by the 'urn:xmpp:fast:0' namespace,
+                // > within its SASL2 authentication request.
+                // - https://xmpp.org/extensions/xep-0484.html#fast-auth
+                authenticate
+                    .c("fast", {
+                        'xmlns': this.NS,
+                        // replay protection
+                        // > Servers MUST reject any authentication requests received via
+                        // > TLS 0-RTT payloads that do not include a 'count' attribute
+                        // - https://xmpp.org/extensions/xep-0484.html#fast-auth
+                        'count': this.credential.counter.toString()
+                    }).up()
+                // > The value of this attribute MUST be a positive integer, which is
+                // >  incremented by the client on every authentication attempt
+                // - https://xmpp.org/extensions/xep-0484.html#fast-auth
+                this.credential.counter++;
+            } else {
+                // When authenticating with a different-than-current FAST mechanism
+                // initiate FAST by sending <request-token>
+                let other_mechanisms = [...this.mechanisms ?? []].filter((m) => m != mechname)
+                if (other_mechanisms.length > 0) {
+
+                    // just pick the first mechanism
+                    let mechname = other_mechanisms[0]
+
+                    // remember which one we picked because the server won't tell us
+                    this.credential = { ...this.credential, 'mechanism': mechname }
+
+                    // send it
+                    authenticate
+                        .c('request-token', {
+                            'xmlns': this.NS,
+                            'mechanism': mechname,
+                        }).up()
+                }
+            }
+
+            return authenticate;
+        }
+
+        // **MONKEY-PATCH** connection to catch the logout event
+        let reset = this.conn.reset.bind(this.conn)
+        this.conn.reset = () => {
+            this.logout.bind(this)().then(() => {
+		reset()
+	    })
+        }
+    },
+
+    /**
+     * 
+     * @param {Number} status 
+     */
+    statusChanged: function (status) {
+        if (status === Status.CONNECTING) {
+            // Register listeners before we get data (CONNECTING) so
+            // we can catch the crucial first stanzas
+            this.conn._addSysNSHandler(this.onAuth.bind(this), this.NS, 'fast');
+            this.conn._addSysNSHandler(this.onToken.bind(this), this.NS, 'token');
+
+            // Load token from passed in credentials, if given,
+            // Make sure to synchronize token's clientID with SASL2;
+            // clientID is optional for SASL2 but unfortunately mandatory for FAST
+            // > MUST also provide the a SASL2 <user-agent> element with an 'id' attribute
+            // > (both of these values are discussed in more detail in XEP-0388).
+            // - https://xmpp.org/extensions/xep-0484.html#rules-clients
+            // Simply: clientID plays the role of username and token the role of password.
+            const { pass } = this.conn;
+            if (pass.token) {
+                this.credential = /** @type {FastCredential} */ pass;
+                this.conn.sasl2.clientID = this.credential.clientID
+            } else {
+                //
+                this.credential = {
+                    'clientID': this.conn.sasl2.clientID,
+                }
+            }
+        }
+    },
+
+    /**
+     * @param {Element} elem 
+     */
+    onAuth: function (elem) {
+
+        // Note: this looks *a lot* like sasl2.onAuth(),
+        // but it runs on a different tag, a sub-tag of the main <authentication> stanza
+
+        const server_mechanisms = new Set([...elem.querySelectorAll('mechanism')]
+            .map((m) => m.textContent));
+
+        this.mechanisms = [...server_mechanisms
+            .intersection(
+                new Set(Object.keys(this.conn.mechanisms))
+            )];
+        // sort by priority
+        this.mechanisms.sort((a, b) => {
+            (this.conn.mechanisms[b].priority - this.conn.mechanisms[a].priority)
+        })
+
+        console.info(
+            "FAST: server advertised ", server_mechanisms,
+            " of which we support", this.mechanisms);
+        if (this.mechanisms.length == 0) {
+            console.warn("FAST offered but with no known mechanisms.");
+            return
+        }
+
+        // Append to the list of SASL2 mechanisms
+        // XXX what happens if this runs before sasl2.onAuth()?
+        this.conn.sasl2.mechanisms = [...
+            new Set(this.conn.sasl2.mechanism)
+                .union(new Set(this.mechanisms))
+        ];
+        // sort by priority XXX the FAST mechanisms should have higher priority!
+        this.conn.sasl2.mechanisms.sort((a, b) => {
+            return (this.conn.mechanisms[b].priority - this.conn.mechanisms[a].priority)
+        })
+
+        return false; // stop listening
+    },
+
+    /**
+     * @param {Element} elem 
+     */
+    onToken: function (elem) {
+
+        this.credential = {
+            ...this.credential,
+            'token': elem.getAttribute('token'),
+            'expiry': Date.parse(elem.getAttribute('expiry')),
+            'counter': 0,
+        };
+        console.log("fast plugin onToken", elem, this.credential)
+
+        return true; // keep listening: the server is allowed to rotate our token anytime it wishes
+    },
+
+    logout: async function () {
+        // Invalidate the FAST token on log out
+        // XXX this does not seem to actually get sent,
+        // and Converse does not forget the token from its IndexedDB
+        // if you edit Local Storage using the web debugger to re-add conversejs-session-jid: 'user@xmpp.example.org'
+        // and reload then FAST will happily log you back in
+
+        if (this.credential.token) {
+            let authenticate = await this.conn.sasl2.authenticateStanza(this.credential.mechanism)
+
+            // XXX copy-pasta
+            const response = await this.conn.mechanisms[this.credential.mechanism].clientChallenge(this.conn);
+            authenticate
+                .c('initial-response',
+                    null,
+                    btoa(/** @type {string} */(response)))
+                .up();
+
+            authenticate.nodeTree.querySelector("fast")?.setAttribute("invalidate", "true")
+
+            this.conn.send(authenticate.tree())
+        }
+    }
+};
+
+export default FAST;

--- a/src/scram.js
+++ b/src/scram.js
@@ -127,15 +127,24 @@ function generate_cnonce() {
 }
 
 /**
- * @typedef {Object} Password
- * @property {string} Password.name
- * @property {string} Password.ck
- * @property {string} Password.sk
- * @property {number} Password.iter
- * @property {string} salt
+ * @typedef {Object} SCRAMKey
+ * @property {string} SCRAMKey.name
+ * @property {string} SCRAMKey.ck
+ * @property {string} SCRAMKey.sk
+ * @property {number} SCRAMKeyiter
+ * @property {string} SCRAMKey.salt
  */
 
 const scram = {
+    test: function (connection, hashName, hashBits) {
+        return true; // XXX debug
+        return connection.authcid !== null
+            && (
+                (typeof connection.pass === 'string' || connection.pass instanceof String)
+                || (connection.pass?.name === hashName)
+            );
+    },
+
     /**
      * On success, sets
      * connection_sasl_data["server-signature"]
@@ -178,9 +187,9 @@ const scram = {
             serverKey = keys.sk;
         } else if (
             // Either restore the client key and server key passed in, or derive new ones
-            /** @type {Password} */ (pass)?.name === hashName &&
-            /** @type {Password} */ (pass)?.salt === utils.arrayBufToBase64(challengeData.salt) &&
-            /** @type {Password} */ (pass)?.iter === challengeData.iter
+            /** @type {SCRAMKey} */ (pass)?.name === hashName &&
+            /** @type {SCRAMKey} */ (pass)?.salt === utils.arrayBufToBase64(challengeData.salt) &&
+            /** @type {SCRAMKey} */ (pass)?.iter === challengeData.iter
         ) {
             const { ck, sk } = /** @type {Password} */ (pass);
             clientKey = utils.base64ToArrayBuf(ck);

--- a/src/scram.js
+++ b/src/scram.js
@@ -137,7 +137,6 @@ function generate_cnonce() {
 
 const scram = {
     test: function (connection, hashName, hashBits) {
-        return true; // XXX debug
         return connection.authcid !== null
             && (
                 (typeof connection.pass === 'string' || connection.pass instanceof String)

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -67,6 +67,7 @@ class Websocket {
         return $build('open', {
             'xmlns': NS.FRAMING,
             'to': this._conn.domain,
+            ...((this._conn.service.startsWith("wss") || this._conn.service.startsWith("ws://localhost")) ? { 'from': this._conn.jid } : {}),
             'version': '1.0',
         });
     }


### PR DESCRIPTION
[FAST](https://xmpp.org/extensions/xep-0484.html) is a cookie-style authentication method that lets clients store and auth with an unguesseable token. It enables clients to forget the user's full password, which is especially important for web-based clients, that are prone to data leaks. Leaked tokens can be invalidated.

This my second attempt, and supersedes #839 .

- https://xmpp.org/extensions/xep-0484.html
- https://xmpp.org/extensions/xep-0388.html

Intended to fix https://github.com/conversejs/converse.js/issues/3144

Some aside changes I needed for this:
- I let handlers listen to the *opening* stanza
- Set 'from' on the opening <stream> tag. (ref: https://github.com/xmppjs/xmpp.js/pull/1006/files#r1893267922)
- Create a type of handler that can search *nested data*. This made setting up listeners a lot more convenient.
- During connection, replace has_features with the direct XML <stream:features> more direct and defensive.
- Moved Status.AUTHENTICATING before FAST/SASL

## Testing

On a prosody server, set these `modules_enabled`:

```
	-- SASL2/FAST
		"sasl2";
		"sasl2_bind2";
		"sasl2_sm";
		"sasl2_fast";
		"client_management";
```

Make or pick a test account on your server to test with.


Then run the client with:

```
git clone -b sasl2_fast_2 git@github.com:kousu/strophejs
git clone -b sasl2_fast_2 git@github.com:kousu/converse.js
cd converse.js
```

Edit converse.js/dev.html to change the prefilled username to match your server (or just be ready to type it in)

```
npm ci
npm run serve & npm run watch & xdg-open https://localhost:8080/dev.html
```

## TODO:

- [ ] Test under both websocket and BOSH
- [ ] Invalidate token on logout
    - [x] In the corresponding Converse.js branch, actually forget the token on logout
- [x] Under my over eager autoformatter
- [ ]  support the other HT- methods from the spec
- [ ] Disentangle the circular dependency between index.js loading sasl2.js/sasl2_fast.js but them needing to talk to Strophe
- [ ] Check and provide proper copyright notice for the snippet I took from xmpp.js

Potential follow ups:
- [ ] rewrite the SASL code into an event-based `src/sasl.js` to make it look like `src/sasl2.js`
- [ ] allow _fallback_ from SASL2 to SASL and between SASL methods

    (currently assumes only ONE login method will be tried per connect(), which could block login if one is failing)
